### PR TITLE
fix: use updated component-classes in alert

### DIFF
--- a/components/alert/w-alert.vue
+++ b/components/alert/w-alert.vue
@@ -23,7 +23,8 @@
               <path d="M7.25 12a.75.75 0 0 0 1.5 0V8a.75.75 0 0 0-1.5 0v4ZM8 4a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" fill="#fff" />
             </svg>
           </div>
-          <div class="last-child:mb-0 text-14" data-test="content">
+          <!-- TODO: replace text-14 with a token -->
+          <div class="last:mb-0 text-14" data-test="content">
             <p class="font-bold" v-if="title">{{ title }}</p>
             <slot />
           </div>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/uno": "1.0.0-alpha.5",
-    "@warp-ds/component-classes": "^1.0.0-alpha.13",
+    "@warp-ds/component-classes": "^1.0.0-alpha.15",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "drnm": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@vitejs/plugin-vue': ^4.1.0
   '@vue/compiler-sfc': ^3.2.37
   '@vue/test-utils': ^2.0.2
-  '@warp-ds/component-classes': ^1.0.0-alpha.13
+  '@warp-ds/component-classes': ^1.0.0-alpha.15
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: ^1.0.0
   create-v-model: ^2.1.2
@@ -55,7 +55,7 @@ devDependencies:
   '@vitejs/plugin-vue': 4.1.0_vite@4.2.1+vue@3.2.47
   '@vue/compiler-sfc': 3.2.47
   '@vue/test-utils': 2.3.0_vue@3.2.47
-  '@warp-ds/component-classes': 1.0.0-alpha.13
+  '@warp-ds/component-classes': 1.0.0-alpha.15
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: 1.0.0
   cz-conventional-changelog: 3.3.0
@@ -1271,8 +1271,8 @@ packages:
       '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.13:
-    resolution: {integrity: sha512-p2TVRzhObUE/iTDtMx5WPfX7BXleNRbjSKwTD/kTgn6uv+/AdQkoXUV+4PxmZZaVgQdQ8TwlEnuOrzFkKmvxLg==}
+  /@warp-ds/component-classes/1.0.0-alpha.15:
+    resolution: {integrity: sha512-bNxvVRDd6vRdhRABeCXH+O21Cb85RUUajg5CMVFoYnBlgEx9wjHrozHAW+oCYsOk+OspTGjJZw6V/U1dCJj3tw==}
     dev: true
 
   /@warp-ds/uno/1.0.0-alpha.5:


### PR DESCRIPTION
## Changes
- bump `@warp-ds/component-classes` to `1.0.0-alpha.15` to apply updated styles to the alert icon ([changelog](https://github.com/warp-ds/component-classes/blob/alpha/CHANGELOG.md#100-alpha15-2023-04-05))
- fix class for controlling bottom margin of last child (`last-child:` was renamed to `last:` in @warp-ds/uno)

### Note
-  until we handle typography, components will look a bit off compared to fabric components

<img width="477" alt="Screenshot 2023-04-05 at 11 02 44" src="https://user-images.githubusercontent.com/41303231/230034295-db9826ce-cb96-4744-a1ab-ef635c017fc9.png">
