### PR TITLE
feat(workflows): add eik aliasing script to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
       - name: Eik login and publish
-        run: pnpm eik login -k $EIK_TOKEN && pnpm eik publish || true
+        run: pnpm eik login -k $EIK_TOKEN && pnpm eik publish && pnpm eik pkg-alias || true
         env:
           EIK_TOKEN: ${{ secrets.EIK_TOKEN }}


### PR DESCRIPTION
Allow the latest version of the package to be imported from eik server without the need to update the version number every time a new bundle version is published.
`https://assets.finn.no/pkg/@warp-ds/vue/v1/warp-vue.js` 
instead of
`https://assets.finn.no/pkg/@warp-ds/vue/v1.0.0-alpha.9/warp-vue.js`

More info on aliases in eik can be found [here](https://eik.dev/docs/client_aliases/).

When `1.0.0` version is published to NPM (`alpha` is merged to `main`), the `eik pkg-alias` script should only be run on pushes to `main`, which will be handled in [this task](https://trello.com/c/IfLXuWlg).