### PR TITLE
fix: add classes to textfield and textarea

### DIFF
--- a/components/forms/w-affix.vue
+++ b/components/forms/w-affix.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { suffix, prefix } from '@fabric-ds/css/component-classes'
+import { suffix, prefix } from '@warp-ds/component-classes'
 import { computed } from 'vue'
 
 export default {

--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,9 +1,9 @@
 <template>
   <component :is="as" :class="{[input.wrapper]: true, [input.invalid]: hasErrorMessage, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
-    <component :is="labelType" v-if="label" :class="{[l.label]: true, [l.labelValid]: !hasErrorMessage, [l.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="input.optional"> (valgfritt)</span></component>
+    <component :is="labelType" v-if="label" :class="{[l.label]: true, [l.labelValid]: !hasErrorMessage, [l.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="l.optional"> (valgfritt)</span></component>
     <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" />
     <slot name="control" :form="collector" />
-    <div :class="{[h.helpText]: true, [h.helpTextValid]: !hasErrorMessage, [h.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">
+    <div :class="{[h.helpText]: true, [h.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">
       <span :id="hintId" v-if="hint" v-html="hint" />
       <span v-if="hint && hasErrorMessage">, </span>
       <span :id="errorId" v-if="hasErrorMessage">{{ validationMsg }}</span>

--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,9 +1,8 @@
 <template>
-  <component :is="as" class="field" :class="{ 'is-invalid': hasErrorMessage, 'is-disabled': disabled, [$attrs.class || '']: true }" :role="role" v-bind="wrapperAria">
-    <component :is="labelType" v-if="label" class="field-label" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" class="pl-8 font-normal text-14 text-gray-500"> (valgfritt)</span></component>
-    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" />
+  <component :is="as" class="relative" :class="{[input.invalid]: hasErrorMessage, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
+    <component :is="labelType" v-if="label" :class="{[l.label]: true, [l.labelValid]: !hasErrorMessage, [l.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="input.optional"> (valgfritt)</span></component>    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" />
     <slot name="control" :form="collector" />
-    <div class="field-hint" v-if="hint || hasErrorMessage">
+    <div :class="{[h.helpText]: true, [h.helpTextValid]: !hasErrorMessage, [h.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">
       <span :id="hintId" v-if="hint" v-html="hint" />
       <span v-if="hint && hasErrorMessage">, </span>
       <span :id="errorId" v-if="hasErrorMessage">{{ validationMsg }}</span>
@@ -12,10 +11,11 @@
 </template>
 
 <script>
-import { computed } from 'vue'
-import { createValidation } from './validation'
-import { id } from '#util'
-import { modelProps } from 'create-v-model'
+import { computed } from 'vue';
+import { input, label as l, helpText as h} from '@warp-ds/component-classes';
+import { createValidation } from './validation';
+import { id } from '#util';
+import { modelProps } from 'create-v-model';
 
 export const fieldProps = {
   id,
@@ -65,7 +65,7 @@ export default {
     }))
     const wrapperAria = computed(() => valueOrUndefined(isFieldset.value, aria.value))
 
-    return { triggerValidation, validationMsg, hasErrorMessage, labelType, labelFor, labelId, hintId, errorId, aria, wrapperAria, collector, valueOrUndefined }
+    return { triggerValidation, validationMsg, hasErrorMessage, labelType, labelFor, labelId, hintId, errorId, aria, wrapperAria, collector, valueOrUndefined, input, l, h }
   }
 }
 </script>

--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,6 +1,7 @@
 <template>
-  <component :is="as" class="relative" :class="{[input.invalid]: hasErrorMessage, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
-    <component :is="labelType" v-if="label" :class="{[l.label]: true, [l.labelValid]: !hasErrorMessage, [l.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="input.optional"> (valgfritt)</span></component>    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" />
+  <component :is="as" :class="{[input.wrapper]: true, [input.invalid]: hasErrorMessage, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
+    <component :is="labelType" v-if="label" :class="{[l.label]: true, [l.labelValid]: !hasErrorMessage, [l.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="input.optional"> (valgfritt)</span></component>
+    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" />
     <slot name="control" :form="collector" />
     <div :class="{[h.helpText]: true, [h.helpTextValid]: !hasErrorMessage, [h.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">
       <span :id="hintId" v-if="hint" v-html="hint" />

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -48,6 +48,7 @@ export default {
       [input.invalid]: props.invalid,
       [input.disabled]: props.disabled,
       [input.readOnly]: props.readOnly,
+      [input.placeholder]: !!props.placeholder,
     }));
     return { model, inputEl, inputClasses, wrapperClass }
   }

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -1,14 +1,14 @@
 <template>
   <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria }">
-      <div :class="[inputWrapperClass, wrapperClass]">
+      <div :class="[input.wrapper, inputWrapperClass]">
       <slot name="prefix" :inputElement="inputEl" />
       <input v-if="mask" :class="inputClasses" v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type">
       <input v-else 
       :class="[
         inputClasses,
         {
-          'pr-40': $slots.suffix,
-          'pl-40': $slots.prefix,    
+          [input.suffix]: $slots.suffix,
+          [input.prefix]: $slots.prefix,    
         }
       ]"
       v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type" v-model="model">
@@ -42,7 +42,6 @@ export default {
     const model = createModel({ props, emit })
     const inputEl = ref(null)
     if (props.mask) setupMask({ props, emit, inputEl });
-    const wrapperClass = input.wrapper;
     const inputClasses = computed(() => ({
       [input.default]: true,
       [input.invalid]: props.invalid,
@@ -50,7 +49,7 @@ export default {
       [input.readOnly]: props.readOnly,
       [input.placeholder]: !!props.placeholder,
     }));
-    return { model, inputEl, inputClasses, wrapperClass }
+    return { model, inputEl, inputClasses, input }
   }
 }
 </script>

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -1,6 +1,6 @@
 <template>
   <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria }">
-      <div :class="[inputWrapperClass, wrapperClass ]">
+      <div :class="[inputWrapperClass, wrapperClass]">
       <slot name="prefix" :inputElement="inputEl" />
       <input v-if="mask" :class="inputClasses" v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type">
       <input v-else 

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -1,19 +1,28 @@
 <template>
-  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria }" :class="{ 'has-suffix': $slots.suffix, 'has-prefix': $slots.prefix }">
-    <div class="input" :class="inputWrapperClass">
+  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria }">
+      <div :class="[inputWrapperClass, wrapperClass ]">
       <slot name="prefix" :inputElement="inputEl" />
-      <input v-if="mask" v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type">
-      <input v-else      v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type" v-model="model">
+      <input v-if="mask" :class="inputClasses" v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type">
+      <input v-else 
+      :class="[
+        inputClasses,
+        {
+          'pr-40': $slots.suffix,
+          'pl-40': $slots.prefix,    
+        }
+      ]"
+      v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type" v-model="model">
       <slot name="suffix" :inputElement="inputEl" />
     </div>
   </w-field>
 </template>
 
 <script>
-import { ref } from 'vue'
-import { createModel } from 'create-v-model'
-import { setupMask } from './w-input-mask.js'
-import { default as wField, fieldProps } from './w-field.vue'
+import { ref, computed } from 'vue';
+import { input } from '@warp-ds/component-classes';
+import { createModel } from 'create-v-model';
+import { setupMask } from './w-input-mask.js';
+import { default as wField, fieldProps } from './w-field.vue';
 
 export default {
   name: 'wInput',
@@ -32,8 +41,15 @@ export default {
   setup(props, { emit }) {
     const model = createModel({ props, emit })
     const inputEl = ref(null)
-    if (props.mask) setupMask({ props, emit, inputEl })
-    return { model, inputEl }
+    if (props.mask) setupMask({ props, emit, inputEl });
+    const wrapperClass = input.wrapper;
+    const inputClasses = computed(() => ({
+      [input.default]: true,
+      [input.invalid]: props.invalid,
+      [input.disabled]: props.disabled,
+      [input.readOnly]: props.readOnly,
+    }));
+    return { model, inputEl, inputClasses, wrapperClass }
   }
 }
 </script>

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -37,6 +37,10 @@ export default {
     inputWrapperClass: String,
     autocomplete: { type: String, default: 'off' },
     mask: Object,
+    invalid: Boolean,
+    disabled: Boolean,
+    readOnly: Boolean,
+    placeholder: String
   },
   setup(props, { emit }) {
     const model = createModel({ props, emit })

--- a/components/forms/w-suffix.vue
+++ b/components/forms/w-suffix.vue
@@ -8,7 +8,7 @@
 
 <script>
 import { onMounted } from 'vue'
-import { suffix as c } from '@fabric-ds/css/component-classes'
+import { suffix as c } from '@warp-ds/component-classes'
 
 export default {
   name: 'wSuffix',

--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -16,7 +16,13 @@ export default {
   name: 'wTextarea',
   components: { wField },
   inheritAttrs: false,
-  props: fieldProps,
+  props: {
+    ...fieldProps,
+    invalid: Boolean,
+    disabled: Boolean,
+    readOnly: Boolean,
+    placeholder: String
+  },
   setup: (props, { emit }) => {
     const wrapperClass = input.wrapper;
     const inputClasses = computed(() => ({

--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -24,6 +24,7 @@ export default {
     [input.invalid]: props.invalid,
     [input.disabled]: props.disabled,
     [input.readOnly]: props.readOnly,
+    [input.placeholder]: !!props.placeholder,
     }));
     const model = createModel({ props, emit });
     return { model, inputClasses, wrapperClass }

--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -1,22 +1,32 @@
 <template>
   <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation }">
-    <div class="input input--textarea mb-0">
-      <textarea v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" />
+    <div :class="wrapperClass">
+      <textarea :class="inputClasses" v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" />
     </div>
   </w-field>
 </template>
 
 <script>
-import { createModel } from 'create-v-model'
-import { default as wField, fieldProps } from './w-field.vue'
+import { computed } from 'vue';
+import { input } from '@warp-ds/component-classes';
+import { createModel } from 'create-v-model';
+import { default as wField, fieldProps } from './w-field.vue';
 
 export default {
   name: 'wTextarea',
   components: { wField },
   inheritAttrs: false,
   props: fieldProps,
-  setup: (props, { emit }) => ({
-    model: createModel({ props, emit })
-  })
+  setup: (props, { emit }) => {
+    const wrapperClass = input.wrapper;
+    const inputClasses = computed(() => ({
+    [input.default]: true,
+    [input.invalid]: props.invalid,
+    [input.disabled]: props.disabled,
+    [input.readOnly]: props.readOnly,
+    }));
+    const model = createModel({ props, emit });
+    return { model, inputClasses, wrapperClass }
+  }
 }
 </script>

--- a/dev/pages/Input.vue
+++ b/dev/pages/Input.vue
@@ -40,7 +40,7 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
     </token>
 
     <token :state="inputModel">
-      <w-input #suffix :disabled="true" v-model="inputModel" label="I am disabled">
+      <w-input #suffix :disabled=true v-model="inputModel" label="I am disabled">
         <w-affix suffix label="NOK" />
       </w-input>
     </token>

--- a/dev/pages/Input.vue
+++ b/dev/pages/Input.vue
@@ -2,7 +2,10 @@
 import { ref } from 'vue'
 import { wInput, wAffix } from '#components'
 
-const inputModel = ref('')
+const inputModel = ref('');
+
+const placeholderModel = ref("some text");
+
 const handleClear = (el) => {
   inputModel.value = ''
   el.focus()
@@ -25,8 +28,26 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
     </token>
 
     <token :state="inputModel">
-      <w-input #prefix v-model="inputModel" label="I have a prefix" class="mb-16" input-wrapper-class="w-1/2">
+      <w-input #prefix v-model="inputModel" label="I have a prefix">
         <w-affix prefix label="+47" />
+      </w-input>
+    </token>
+
+    <token :state="inputModel">
+      <w-input #suffix v-model="inputModel" label="I have a suffix">
+        <w-affix suffix label="NOK" />
+      </w-input>
+    </token>
+
+    <token :state="inputModel">
+      <w-input #suffix :disabled="true" v-model="inputModel" label="I am disabled">
+        <w-affix suffix label="NOK" />
+      </w-input>
+    </token>
+
+    <token :state="inputModel">
+      <w-input :readOnly="true"  v-model="placeholderModel" label="I am read only">
+        <w-affix suffix label="NOK" />
       </w-input>
     </token>
 

--- a/dev/pages/Textarea.vue
+++ b/dev/pages/Textarea.vue
@@ -13,7 +13,7 @@ const model = ref('')
       <w-textarea v-model="model" label="Such area, much text" />
     </token>
     <token :state="model">
-      <w-textarea :disabled="true" v-model="model" label="Disabled textarea" />
+      <w-textarea :disabled=true v-model="model" label="Disabled textarea" />
     </token>
 
     <token :state="model">

--- a/dev/pages/Textarea.vue
+++ b/dev/pages/Textarea.vue
@@ -12,5 +12,16 @@ const model = ref('')
     <token :state="model">
       <w-textarea v-model="model" label="Such area, much text" />
     </token>
+    <token :state="model">
+      <w-textarea :disabled="true" v-model="model" label="Disabled textarea" />
+    </token>
+
+    <token :state="model">
+      <w-textarea :readOnly="true" v-model="model" label="Such area, much text" />
+    </token>
+
+    <token :state="model" >
+      <w-textarea v-model="model" required label="A required textarea" hint="A hint" />
+    </token>
   </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/uno": "1.0.0-alpha.5",
-    "@warp-ds/component-classes": "^1.0.0-alpha.30",
+    "@warp-ds/component-classes": "^1.0.0-alpha.31",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "drnm": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/uno": "1.0.0-alpha.5",
-    "@warp-ds/component-classes": "^1.0.0-alpha.31",
+    "@warp-ds/component-classes": "^1.0.0-alpha.32",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "drnm": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/uno": "1.0.0-alpha.5",
-    "@warp-ds/component-classes": "^1.0.0-alpha.20",
+    "@warp-ds/component-classes": "^1.0.0-alpha.30",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "drnm": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@vitejs/plugin-vue': ^4.1.0
   '@vue/compiler-sfc': ^3.2.37
   '@vue/test-utils': ^2.0.2
-  '@warp-ds/component-classes': ^1.0.0-alpha.30
+  '@warp-ds/component-classes': ^1.0.0-alpha.31
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: ^1.0.0
   create-v-model: ^2.1.2
@@ -55,7 +55,7 @@ devDependencies:
   '@vitejs/plugin-vue': 4.1.0_vite@4.2.1+vue@3.2.47
   '@vue/compiler-sfc': 3.2.47
   '@vue/test-utils': 2.3.0_vue@3.2.47
-  '@warp-ds/component-classes': 1.0.0-alpha.30
+  '@warp-ds/component-classes': 1.0.0-alpha.31
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: 1.0.0
   cz-conventional-changelog: 3.3.0
@@ -1271,8 +1271,8 @@ packages:
       '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.30:
-    resolution: {integrity: sha512-DoB6b81LSyayoQ65th6Qt/igvjZ52V0GQJe33ZtEtqmgFKz40rgzaiPj5Vng9dJN7qztcExvPQOmTET+TSmXzg==}
+  /@warp-ds/component-classes/1.0.0-alpha.31:
+    resolution: {integrity: sha512-gqoxHbj1YA4d8E6+9DAvPX1w0BwcJfx/P99IeBG9u/QXoHDsV9zl90B74qFCmw8Uei1n2pG25m2sOf/J5hRzXg==}
     dev: true
 
   /@warp-ds/uno/1.0.0-alpha.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@vitejs/plugin-vue': ^4.1.0
   '@vue/compiler-sfc': ^3.2.37
   '@vue/test-utils': ^2.0.2
-  '@warp-ds/component-classes': ^1.0.0-alpha.31
+  '@warp-ds/component-classes': ^1.0.0-alpha.32
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: ^1.0.0
   create-v-model: ^2.1.2
@@ -55,7 +55,7 @@ devDependencies:
   '@vitejs/plugin-vue': 4.1.0_vite@4.2.1+vue@3.2.47
   '@vue/compiler-sfc': 3.2.47
   '@vue/test-utils': 2.3.0_vue@3.2.47
-  '@warp-ds/component-classes': 1.0.0-alpha.31
+  '@warp-ds/component-classes': 1.0.0-alpha.32
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: 1.0.0
   cz-conventional-changelog: 3.3.0
@@ -1271,8 +1271,8 @@ packages:
       '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.31:
-    resolution: {integrity: sha512-gqoxHbj1YA4d8E6+9DAvPX1w0BwcJfx/P99IeBG9u/QXoHDsV9zl90B74qFCmw8Uei1n2pG25m2sOf/J5hRzXg==}
+  /@warp-ds/component-classes/1.0.0-alpha.32:
+    resolution: {integrity: sha512-EeChnPiD+6HvJfm/8iMpUiD/h+cI36/bGnbrV6qvB7VNhTYunoNINMOfLaBOAJF1ENOExLjnMJP6D2HTr3AznQ==}
     dev: true
 
   /@warp-ds/uno/1.0.0-alpha.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@vitejs/plugin-vue': ^4.1.0
   '@vue/compiler-sfc': ^3.2.37
   '@vue/test-utils': ^2.0.2
-  '@warp-ds/component-classes': ^1.0.0-alpha.20
+  '@warp-ds/component-classes': ^1.0.0-alpha.30
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: ^1.0.0
   create-v-model: ^2.1.2
@@ -55,7 +55,7 @@ devDependencies:
   '@vitejs/plugin-vue': 4.1.0_vite@4.2.1+vue@3.2.47
   '@vue/compiler-sfc': 3.2.47
   '@vue/test-utils': 2.3.0_vue@3.2.47
-  '@warp-ds/component-classes': 1.0.0-alpha.20
+  '@warp-ds/component-classes': 1.0.0-alpha.30
   '@warp-ds/uno': 1.0.0-alpha.5
   cleave-lite: 1.0.0
   cz-conventional-changelog: 3.3.0
@@ -1271,8 +1271,8 @@ packages:
       '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.20:
-    resolution: {integrity: sha512-vNNW2MFOkP+GPsQ3WfZh8jRhPjXk0jYHSb+aKAcWwlgQLm1DKn3P6yJEKiK/THKInzYpqms/SxmZfZtRk+9fZA==}
+  /@warp-ds/component-classes/1.0.0-alpha.30:
+    resolution: {integrity: sha512-DoB6b81LSyayoQ65th6Qt/igvjZ52V0GQJe33ZtEtqmgFKz40rgzaiPj5Vng9dJN7qztcExvPQOmTET+TSmXzg==}
     dev: true
 
   /@warp-ds/uno/1.0.0-alpha.5:

--- a/test/wInput.test.js
+++ b/test/wInput.test.js
@@ -20,7 +20,7 @@ describe('input', () => {
         suffix: '<h2>Warp</h2>'
       }
     })
-    const content = wrapper.get('div.input')
+    const content = wrapper.get('div')
     assert.equal(content.text(), 'HelloWarp')
     assert.include(content.html(), '<h1>Hello</h1>')
   })


### PR DESCRIPTION
Styles were migrated from https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/field.css and  https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/form-elements.css

Design here: https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Component-library?node-id=393-38455&t=2Rt4QOodGYjj5KNF-0
Old docs: https://vue.fabric-ds.io/forms