### PR TITLE
fix: do not override props and attrs in input and textarea

### DIFF
--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,7 +1,7 @@
 <template>
-  <component :is="as" :class="{[ccInput.wrapper]: true, [ccInput.invalid]: hasErrorMessage, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
+  <component :is="as" :class="{[ccInput.wrapper]: true, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
     <component :is="labelType" v-if="label" :class="{[ccLabel.label]: true, [ccLabel.labelValid]: !hasErrorMessage, [ccLabel.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional"> (valgfritt)</span></component>
-    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" />
+    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" :hasValidationErrors="hasValidationErrors" />
     <slot name="control" :form="collector" />
     <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">
       <span :id="hintId" v-if="hint" v-html="hint" />
@@ -65,8 +65,8 @@ export default {
       'aria-required': props.required && true
     }))
     const wrapperAria = computed(() => valueOrUndefined(isFieldset.value, aria.value))
-
-    return { triggerValidation, validationMsg, hasErrorMessage, labelType, labelFor, labelId, hintId, errorId, aria, wrapperAria, collector, valueOrUndefined, ccInput, ccLabel, ccHelpText }
+    const hasValidationErrors = computed(() => !!hasErrorMessage.value);
+    return { triggerValidation, validationMsg, hasErrorMessage, labelType, labelFor, labelId, hintId, errorId, aria, wrapperAria, collector, valueOrUndefined, ccInput, ccLabel, ccHelpText, hasValidationErrors }
   }
 }
 </script>

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -1,34 +1,40 @@
 <template>
-  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria }">
-      <div :class="[ccInput.wrapper, inputWrapperClass]">
+  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria, hasValidationErrors }">
+      <div :class="[inputWrapperClass, ccInput.wrapper]">
       <slot name="prefix" :inputElement="inputEl" />
-      <input v-if="mask" :class="inputClasses" v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type">
-      <input v-else 
-      :class="[
-        inputClasses,
-        {
-          [ccInput.suffix]: $slots.suffix,
-          [ccInput.prefix]: $slots.prefix,    
-        }
-      ]"
-      v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type" v-model="model">
+      <input 
+        v-if="mask"
+        :class="[
+          inputClasses,
+          {
+            [ccInput.invalid]: hasValidationErrors,
+          }
+        ]"
+        v-bind="{ ...aria, ...$attrs, class: '' }"
+        @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type">
+      <input 
+        v-else
+        :class="[
+          inputClasses,
+          {
+            [ccInput.invalid]: hasValidationErrors,
+          }
+        ]"
+        v-bind="{ ...aria, ...$attrs, class: '' }" @blur="triggerValidation" ref="inputEl" :autocomplete="autocomplete" :id="id" :type="type" v-model="model"
+        >
       <slot name="suffix" :inputElement="inputEl" />
     </div>
   </w-field>
 </template>
 
-<script>
-import { ref, computed } from 'vue';
-import { input as ccInput } from '@warp-ds/component-classes';
-import { createModel } from 'create-v-model';
-import { setupMask } from './w-input-mask.js';
-import { default as wField, fieldProps } from './w-field.vue';
+<script setup>
+  import { ref, computed, useAttrs, useSlots } from 'vue';
+  import { input as ccInput } from '@warp-ds/component-classes';
+  import { createModel } from 'create-v-model';
+  import { setupMask } from './w-input-mask.js';
+  import { default as wField, fieldProps } from './w-field.vue';
 
-export default {
-  name: 'wInput',
-  components: { wField },
-  inheritAttrs: false,
-  props: {
+  const props = defineProps({
     ...fieldProps,
     type: {
       type: String,
@@ -37,23 +43,23 @@ export default {
     inputWrapperClass: String,
     autocomplete: { type: String, default: 'off' },
     mask: Object,
-    invalid: Boolean,
-    disabled: Boolean,
-    readOnly: Boolean,
-    placeholder: String
-  },
-  setup(props, { emit }) {
-    const model = createModel({ props, emit })
-    const inputEl = ref(null)
-    if (props.mask) setupMask({ props, emit, inputEl });
-    const inputClasses = computed(() => ({
-      [ccInput.default]: true,
-      [ccInput.invalid]: props.invalid,
-      [ccInput.disabled]: props.disabled,
-      [ccInput.readOnly]: props.readOnly,
-      [ccInput.placeholder]: !!props.placeholder,
-    }));
-    return { model, inputEl, inputClasses, ccInput }
-  }
-}
+  });
+  const {disabled, placeholder, readOnly} = useAttrs();
+  const slots = useSlots();
+  const emit = defineEmits(['update:modelValue']);
+  const model = createModel({ props, emit });
+  const inputEl = ref(null);
+  if (props.mask) setupMask({ props, emit, inputEl });
+  const inputClasses = computed(() => ({
+    [ccInput.default]: true,
+    [ccInput.disabled]: disabled,
+    [ccInput.readOnly]: readOnly !== undefined,
+    [ccInput.placeholder]: !!placeholder,
+    [ccInput.suffix]: slots.suffix,
+    [ccInput.prefix]: slots.prefix,
+  }));
+</script>
+
+<script>
+export default { name: 'wInput', inheritAttrs: false };
 </script>

--- a/components/forms/w-input.vue
+++ b/components/forms/w-input.vue
@@ -1,6 +1,6 @@
 <template>
   <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria, hasValidationErrors }">
-      <div :class="[inputWrapperClass, ccInput.wrapper]">
+      <div :class="[ccInput.wrapper, inputWrapperClass]">
       <slot name="prefix" :inputElement="inputEl" />
       <input 
         v-if="mask"

--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -1,39 +1,41 @@
 <template>
-  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation }">
+  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, hasValidationErrors }">
     <div :class="wrapperClass">
-      <textarea :class="inputClasses" v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" />
+      <textarea         
+        :class="[
+          inputClasses,
+          {
+            [ccInput.invalid]: hasValidationErrors,
+          }
+        ]"
+        v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" 
+      />
     </div>
   </w-field>
 </template>
 
-<script>
-import { computed } from 'vue';
+<script setup>
+import { computed, useAttrs } from 'vue';
 import { input as ccInput } from '@warp-ds/component-classes';
 import { createModel } from 'create-v-model';
 import { default as wField, fieldProps } from './w-field.vue';
 
-export default {
-  name: 'wTextarea',
-  components: { wField },
-  inheritAttrs: false,
-  props: {
+const props = defineProps({
     ...fieldProps,
-    invalid: Boolean,
-    disabled: Boolean,
-    readOnly: Boolean,
-    placeholder: String
-  },
-  setup: (props, { emit }) => {
-    const wrapperClass = ccInput.wrapper;
-    const inputClasses = computed(() => ({
+  });
+  const {disabled, placeholder, readOnly} = useAttrs();
+  const emit = defineEmits(['update:modelValue']);
+  const model = createModel({ props, emit });
+
+  const wrapperClass = ccInput.wrapper;
+  const inputClasses = computed(() => ({
     [`${ccInput.default} ${ccInput.textArea}`]: true,
-    [ccInput.invalid]: props.invalid,
-    [ccInput.disabled]: props.disabled,
-    [ccInput.readOnly]: props.readOnly,
-    [ccInput.placeholder]: !!props.placeholder,
-    }));
-    const model = createModel({ props, emit });
-    return { model, inputClasses, wrapperClass }
-  }
-}
+    [ccInput.disabled]: disabled,
+    [ccInput.readOnly]: readOnly !== undefined,
+    [ccInput.placeholder]: !!placeholder,
+  }));
+</script>
+
+<script>
+export default { name: 'wTextarea', inheritAttrs: false };
 </script>

--- a/dev/pages/Input.vue
+++ b/dev/pages/Input.vue
@@ -4,7 +4,7 @@ import { wInput, wAffix } from '#components'
 
 const inputModel = ref('');
 
-const placeholderModel = ref("some text");
+const placeholderModel = ref('');
 
 const handleClear = (el) => {
   inputModel.value = ''
@@ -28,8 +28,15 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
     </token>
 
     <token :state="inputModel">
-      <w-input #prefix v-model="inputModel" label="I have a prefix">
+      <w-input placeholder="I am placeholder"  #prefix v-model="inputModel" label="I have a prefix">
         <w-affix prefix label="+47" />
+      </w-input>
+    </token>
+
+    <token :state="inputModel">
+      <w-input #prefix #suffix v-model="inputModel" label="I have a prefix">
+        <w-affix prefix label="+47" />
+        <w-affix suffix clear />
       </w-input>
     </token>
 
@@ -46,13 +53,13 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
     </token>
 
     <token :state="inputModel">
-      <w-input :readOnly="true"  v-model="placeholderModel" label="I am read only">
+      <w-input readOnly value="I'm read only" v-model="placeholderModel" label="I am read only">
         <w-affix suffix label="NOK" />
       </w-input>
     </token>
 
     <token :state="numericInputModel">
-      <w-input v-model.number="numericInputModel" optional number type="text" inputmode="numeric" :mask="moneyMask" label="A masked (money) input" />
+      <w-input placeholder="I am placeholder"  v-model.number="numericInputModel" optional number type="text" inputmode="numeric" :mask="moneyMask" label="A masked (money) input" />
     </token>
   </div>
 </template>

--- a/dev/pages/Input.vue
+++ b/dev/pages/Input.vue
@@ -33,6 +33,9 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
       </w-input>
     </token>
 
+    <!-- TODO tabbing through the input and suffix is off for now. We do not have support for adding multiple slots as of now. So both
+    suffix and prefix are treated as one slot in this example, making button(suffix) render before input in DOM and "destroy" the tabbing order.
+    So the support for multiple slots need to be added here -->
     <token :state="inputModel">
       <w-input #prefix #suffix v-model="inputModel" label="I have a prefix">
         <w-affix prefix label="+47" />


### PR DESCRIPTION
- [x] native behaviour is back for disabled, readonly and inputs with placeholder
- [x] style invalid fields on blur only
- [x] refactor using `script setup` to get rid of `setup` and `default` export.

Bugs were found here https://warp-ds.github.io/tech-docs/textfield/

No placeholder when it should be, disabled fields are tab:able