### PR TITLE
fix: add component classes to select

### DIFF
--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,6 +1,6 @@
 <template>
   <component :is="as" :class="{[ccInput.wrapper]: true, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
-    <component :is="labelType" v-if="label" :class="{[ccLabel.label]: true, [ccLabel.labelValid]: !hasErrorMessage, [ccLabel.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional"> (valgfritt)</span></component>
+    <component :is="labelType" v-if="label" :class="{[ccLabel.label]: true, [ccLabel.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional"> (valgfritt)</span></component>
     <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" :hasValidationErrors="hasValidationErrors" />
     <slot name="control" :form="collector" />
     <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">

--- a/components/forms/w-select.vue
+++ b/components/forms/w-select.vue
@@ -1,26 +1,72 @@
 <template>
-  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation }">
-    <div class="input mb-0">
-      <div class="input--select__wrap">
-        <select v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation">
+  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, hasValidationErrors }">
+    <div :class="wrapperClasses">
+      <div :class="selectWrapperClasses">
+        <select
+          :class="[
+            selectClasses,
+            {
+              [ccSelect.invalid]: hasValidationErrors,
+            }
+          ]"
+          v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation">
           <slot />
         </select>
+        <div :class="chevronClasses">
+          <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="none"
+              viewBox="0 0 16 16"
+          >
+            <path
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.5"
+              d="M2.5 5.5L8 11L13.5 5.5"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   </w-field>
 </template>
 
-<script>
+<script setup>
+import { computed, useAttrs } from 'vue';
+import { select as ccSelect } from '@warp-ds/component-classes';
 import { createModel } from 'create-v-model'
 import { default as wField, fieldProps } from './w-field.vue'
 
-export default {
-  name: 'wSelect',
-  components: { wField },
-  inheritAttrs: false,
-  props: fieldProps,
-  setup: (props, { emit }) => ({
-    model: createModel({ props, emit })
-  })
-}
+const props = defineProps(fieldProps);
+const emit = defineEmits(['update:modelValue']);
+const model = createModel({ props, emit });
+
+const {disabled, readOnly} = useAttrs();
+
+const wrapperClasses = computed(() => ({
+  [ccSelect.wrapper]: true
+}));
+
+const selectWrapperClasses = computed(() => ({
+  [ccSelect.selectWrapper]: true
+}));
+
+const selectClasses = computed(() => ({
+  [ccSelect.default]: true,
+  [ccSelect.disabled]: disabled,
+  [ccSelect.readOnly]: readOnly
+}));
+
+const chevronClasses = computed(() => ({
+  [ccSelect.chevron]: true,
+  [ccSelect.chevronDisabled]: disabled,
+}));
+
+</script>
+
+<script>
+export default { name: 'wSelect', inheritAttrs: false };
 </script>

--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -20,20 +20,18 @@ import { input as ccInput } from '@warp-ds/component-classes';
 import { createModel } from 'create-v-model';
 import { default as wField, fieldProps } from './w-field.vue';
 
-const props = defineProps({
-    ...fieldProps,
-  });
-  const {disabled, placeholder, readOnly} = useAttrs();
-  const emit = defineEmits(['update:modelValue']);
-  const model = createModel({ props, emit });
+const props = defineProps(fieldProps);
+const {disabled, placeholder, readOnly} = useAttrs();
+const emit = defineEmits(['update:modelValue']);
+const model = createModel({ props, emit });
 
-  const wrapperClass = ccInput.wrapper;
-  const inputClasses = computed(() => ({
-    [`${ccInput.default} ${ccInput.textArea}`]: true,
-    [ccInput.disabled]: disabled,
-    [ccInput.readOnly]: readOnly !== undefined,
-    [ccInput.placeholder]: !!placeholder,
-  }));
+const wrapperClass = ccInput.wrapper;
+const inputClasses = computed(() => ({
+  [`${ccInput.default} ${ccInput.textArea}`]: true,
+  [ccInput.disabled]: disabled,
+  [ccInput.readOnly]: readOnly !== undefined,
+  [ccInput.placeholder]: !!placeholder,
+}));
 </script>
 
 <script>

--- a/dev/pages/Select.vue
+++ b/dev/pages/Select.vue
@@ -16,5 +16,26 @@ const selectModel = ref('')
         <option value="bar">Bar</option>
       </w-select>
     </token>
+    <token :state="selectModel">
+      <w-select :optional="true" v-model="selectModel" label="A useful and informative label">
+        <option disabled selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </token>
+    <token :state="selectModel">
+      <w-select :disabled=true v-model="selectModel" label="Disabled select">
+        <option disabled selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </token>
+    <token :state="selectModel">
+      <w-select required invalid v-model="selectModel" label="Invalid">
+        <option disabled selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </token>
   </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/uno": "1.0.0-alpha.8",
-    "@warp-ds/component-classes": "^1.0.0-alpha.39",
+    "@warp-ds/component-classes": "^1.0.0-alpha.40",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "drnm": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@vitejs/plugin-vue': ^4.1.0
   '@vue/compiler-sfc': ^3.2.37
   '@vue/test-utils': ^2.0.2
-  '@warp-ds/component-classes': ^1.0.0-alpha.39
+  '@warp-ds/component-classes': ^1.0.0-alpha.40
   '@warp-ds/uno': 1.0.0-alpha.8
   cleave-lite: ^1.0.0
   create-v-model: ^2.1.2
@@ -55,7 +55,7 @@ devDependencies:
   '@vitejs/plugin-vue': 4.1.0_vite@4.2.1+vue@3.2.47
   '@vue/compiler-sfc': 3.2.47
   '@vue/test-utils': 2.3.0_vue@3.2.47
-  '@warp-ds/component-classes': 1.0.0-alpha.39
+  '@warp-ds/component-classes': 1.0.0-alpha.40
   '@warp-ds/uno': 1.0.0-alpha.8
   cleave-lite: 1.0.0
   cz-conventional-changelog: 3.3.0
@@ -1271,8 +1271,8 @@ packages:
       '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.39:
-    resolution: {integrity: sha512-OtwQ+q/fsjRJIOjUSIe36d9rEwzSJ2E7vHLQaWodT4Y2uYpKR6YZpdd1vhMKLeJKQ5mvMjnEldww9+3XOAPSyA==}
+  /@warp-ds/component-classes/1.0.0-alpha.40:
+    resolution: {integrity: sha512-yGKY8XEVXQxmq4q8RqPTiXFv3a95WwNnot135ZDqz50/MaJPY1wpHsgKwvtapO6yy3OJ6CFh0c9klLiITAlxOw==}
     dev: true
 
   /@warp-ds/uno/1.0.0-alpha.8:


### PR DESCRIPTION
Migrated styling from https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/form-elements.css

- Removed `labelValid` as it only was a color and is now a part of the default label styling

Variant|Screenshot
---|---
Standard | <img width="600" alt="image" src="https://user-images.githubusercontent.com/37986637/233102862-ec14c44d-4757-48b5-a2cf-ea1e7fc20ec6.png">
Hint | <img width="595" alt="image" src="https://user-images.githubusercontent.com/37986637/233102959-7457d024-f3bb-410b-afde-ef11d33d862a.png">
Invalid | <img width="599" alt="image" src="https://user-images.githubusercontent.com/37986637/233103055-dad1f531-7aed-4a1b-9bd7-5dfffa8367e8.png">
Disabled | <img width="630" alt="image" src="https://user-images.githubusercontent.com/37986637/233386445-4d3300a4-fa3d-48bc-9532-5e5fa7313a01.png">
No label | <img width="600" alt="image" src="https://user-images.githubusercontent.com/37986637/233103408-73eed912-ada2-4b68-8340-a60405279ee0.png">
Optional | <img width="595" alt="image" src="https://user-images.githubusercontent.com/37986637/233103490-2a4fb1ef-5ab6-4bf6-8e95-b1bdb67f6421.png">

