### PR TITLE
fix: import sr-only class from component-classes in Button and Breadrumbs

### DIFF
--- a/components/breadcrumbs/w-breadcrumbs.vue
+++ b/components/breadcrumbs/w-breadcrumbs.vue
@@ -1,6 +1,6 @@
 <template>
   <nav :aria-label="ariaLabel">
-    <h2 class="sr-only">{{ ariaLabel }} </h2>
+    <h2 :class="ccBreadcrumbs.a11y">{{ ariaLabel }}</h2>
     <div :class="ccBreadcrumbs.wrapper">
       <breadcrumbify>
         <slot />

--- a/components/button/w-button.vue
+++ b/components/button/w-button.vue
@@ -1,7 +1,7 @@
 <template>
   <component :is="href ? 'a' : 'button'" :href="href" :class="buttonClass" v-bind="saneDefaults">
     <slot>{{ label }}</slot>
-    <span v-if="loading" role="progressbar" aria-valuenow="0" aria-valuetext="Laster..." class="sr-only" />
+    <span v-if="loading" role="progressbar" aria-valuenow="0" aria-valuetext="Laster..." :class="ccButton.a11y" />
   </component>
 </template>
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.42",
+    "@warp-ds/component-classes": "^1.0.0-alpha.44",
     "@warp-ds/uno": "1.0.0-alpha.8",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ devDependencies:
     specifier: ^2.0.2
     version: 2.3.0(vue@3.2.47)
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.42
-    version: 1.0.0-alpha.42
+    specifier: ^1.0.0-alpha.44
+    version: 1.0.0-alpha.44
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1305,8 +1305,8 @@ packages:
       '@vue/server-renderer': 3.2.47(vue@3.2.47)
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.42:
-    resolution: {integrity: sha512-5XyKVcvzj7SZXf++avD3EaUdINjrKIxk/pH46zEqACqf4tUYlxDaPP60pw5sgJUQcpYALliOM3PP9On7r/5n+A==}
+  /@warp-ds/component-classes@1.0.0-alpha.44:
+    resolution: {integrity: sha512-rGGJhi7VsezeDg25zrrkA7R6y/0/zKzr5iaYsPTPPFlzcVnbbEil8rnmBr5eOjVXUXp9Wz7f3eVyS68N5jiooA==}
     dev: true
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
Fixes a bug where components nested in shadow dom (like in @warp-ds/tech-docs) wouldn’t work properly with classes that are not added to the safelist of uno config.