### PR TITLE
feat(button-group): add component classes to ButtonGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .idea/
+.vscode

--- a/components/button-group/w-button-group-item.vue
+++ b/components/button-group/w-button-group-item.vue
@@ -11,11 +11,11 @@ const outlinedClass = computed(() => [
   vertical.value ? ccButtonGroupItem.outlinedVertical : ccButtonGroupItem.outlinedHorizontal
 ]);
 
-const outlineResetClass = vertical.value ? ccButtonGroupItem.outlinedVerticalResets : ccButtonGroupItem.outlinedHorizontalResets
+const outlineResetClass = computed(() => [vertical.value ? ccButtonGroupItem.outlinedVerticalResets : ccButtonGroupItem.outlinedHorizontalResets])
 
 const wrapperClass = computed(() => [
   ccButtonGroupItem.wrapper,
-  outlined.value ? outlinedClass.value : outlineResetClass,
+  outlined.value ? outlinedClass.value : outlineResetClass.value,
   props.selected ? ccButtonGroupItem.selected : '',
 ]);
 </script>

--- a/components/button-group/w-button-group-item.vue
+++ b/components/button-group/w-button-group-item.vue
@@ -3,12 +3,17 @@ import { inject, computed } from 'vue'
 
 const props = defineProps({ selected: Boolean });
 const outlined = inject('outlined', false);
+const vertical = inject('vertical', false);
 
-const wrapperClass = computed(() => [
-  'relative last-child:mb-0 hover:i-bg-$gray-50 active:i-bg-$bg-gray-100',
-  outlined.value ? 'i-border-$gray-300' : 'border-transparent',
-  props.selected ? 'i-bg-$gray-200 hover:i-bg-$gray-300 active:i-bg-$gray-400' : 'i-bg-$white'
-]);
+const wrapperClass = computed(() => [{
+  'relative i-text-$color-button-group-text i-bg-$color-button-group-background hover:i-bg-$color-button-group-background-hover active:i-border-$color-button-group-border-active active:i-text-$color-button-group-text-active active:i-bg-$color-button-group-background-active': true,
+  'first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4': vertical.value,
+  'first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4': !vertical.value,
+  'border hover:z-30 i-border-$color-button-group-border hover:i-border-$color-button-group-border-hover active:i-border-$color-button-group-border-active': outlined.value,
+  [vertical.value ? '-mb-1 last:mb-0' : '-mr-1 last:mr-0']: outlined.value,
+  [vertical.value ? 'px-1 pt-1 last:pb-1 -mb-1 last:mb-0' : 'py-1 pl-1 last:pr-1 -mr-1 last:mr-0']: !outlined.value,
+  'z-30 i-text-$color-button-group-text-active! i-bg-$color-button-group-background-active! hover:i-bg-$color-button-group-background-active-hover! i-border-$color-button-group-border-active': props.selected,
+}]);
 </script>
 
 <template>

--- a/components/button-group/w-button-group-item.vue
+++ b/components/button-group/w-button-group-item.vue
@@ -1,19 +1,23 @@
 <script setup>
-import { inject, computed } from 'vue'
+import { inject, computed } from 'vue';
+import { buttonGroupItem as ccButtonGroupItem } from '@warp-ds/component-classes';
 
 const props = defineProps({ selected: Boolean });
 const outlined = inject('outlined', false);
 const vertical = inject('vertical', false);
 
-const wrapperClass = computed(() => [{
-  'relative i-text-$color-button-group-text i-bg-$color-button-group-background hover:i-bg-$color-button-group-background-hover active:i-border-$color-button-group-border-active active:i-text-$color-button-group-text-active active:i-bg-$color-button-group-background-active': true,
-  'first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4': vertical.value,
-  'first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4': !vertical.value,
-  'border hover:z-30 i-border-$color-button-group-border hover:i-border-$color-button-group-border-hover active:i-border-$color-button-group-border-active': outlined.value,
-  [vertical.value ? '-mb-1 last:mb-0' : '-mr-1 last:mr-0']: outlined.value,
-  [vertical.value ? 'px-1 pt-1 last:pb-1 -mb-1 last:mb-0' : 'py-1 pl-1 last:pr-1 -mr-1 last:mr-0']: !outlined.value,
-  'z-30 i-text-$color-button-group-text-active! i-bg-$color-button-group-background-active! hover:i-bg-$color-button-group-background-active-hover! i-border-$color-button-group-border-active': props.selected,
-}]);
+const outlinedClass = computed(() => [
+  ccButtonGroupItem.outlined,
+  vertical.value ? ccButtonGroupItem.outlinedVertical : ccButtonGroupItem.outlinedHorizontal
+]);
+
+const outlineResetClass = vertical.value ? ccButtonGroupItem.outlinedVerticalResets : ccButtonGroupItem.outlinedHorizontalResets
+
+const wrapperClass = computed(() => [
+  ccButtonGroupItem.wrapper,
+  outlined.value ? outlinedClass.value : outlineResetClass,
+  props.selected ? ccButtonGroupItem.selected : '',
+]);
 </script>
 
 <template>

--- a/components/button-group/w-button-group.vue
+++ b/components/button-group/w-button-group.vue
@@ -21,7 +21,7 @@ provide('outlined', toRef(props, 'outlined'))
 provide('vertical', toRef(props, 'vertical'))
 
 const classes = computed(() => ({
-  ['filter drop-shadow-10']: props.raised,
+  ['shadow-small']: props.raised,
   [props.vertical ? 'divide-y' : 'divide-x']: !props.outlined,
   ['flex-col']: props.vertical
 }))

--- a/components/button-group/w-button-group.vue
+++ b/components/button-group/w-button-group.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="f-button-group inline-flex rounded-4 divide-gray-300 overflow-hidden" :class="classes">
+  <div class="inline-flex rounded-4 overflow-hidden" :class="classes">
     <slot />
   </div>
 </template>
@@ -18,11 +18,11 @@ const props = defineProps({
 })
 
 provide('outlined', toRef(props, 'outlined'))
+provide('vertical', toRef(props, 'vertical'))
 
 const classes = computed(() => ({
-  ['border border-gray-300']: props.outlined,
   ['filter drop-shadow-10']: props.raised,
-  [props.vertical ? 'divide-y' : 'divide-x']: true,
+  [props.vertical ? 'divide-y' : 'divide-x']: !props.outlined,
   ['flex-col']: props.vertical
 }))
 </script>

--- a/components/button-group/w-button-group.vue
+++ b/components/button-group/w-button-group.vue
@@ -21,12 +21,12 @@ const props = defineProps({
 provide('outlined', toRef(props, 'outlined'))
 provide('vertical', toRef(props, 'vertical'))
 
-const nonOutlinedClass = props.vertical ? ccButtonGroup.nonOutlinedVertical : ccButtonGroup.nonOutlinedHorizontal
+const nonOutlinedClass = computed(() => [props.vertical ? ccButtonGroup.nonOutlinedVertical : ccButtonGroup.nonOutlinedHorizontal])
 
 const classes = computed(() => [
   ccButtonGroup.wrapper,
   props.raised ? ccButtonGroup.raised : '',
   props.vertical ? ccButtonGroup.vertical : '',
-  props.outlined ? '' : nonOutlinedClass
+  props.outlined ? '' : nonOutlinedClass.value
 ])
 </script>

--- a/components/button-group/w-button-group.vue
+++ b/components/button-group/w-button-group.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="inline-flex rounded-4 overflow-hidden" :class="classes">
+  <div :class="classes">
     <slot />
   </div>
 </template>
@@ -9,7 +9,8 @@ export default { name: 'wButtonGroup' }
 </script>
 
 <script setup>
-import { provide, computed, toRef } from 'vue'
+import { provide, computed, toRef } from 'vue';
+import { buttonGroup as ccButtonGroup } from '@warp-ds/component-classes';
 
 const props = defineProps({
   outlined: Boolean,
@@ -20,9 +21,12 @@ const props = defineProps({
 provide('outlined', toRef(props, 'outlined'))
 provide('vertical', toRef(props, 'vertical'))
 
-const classes = computed(() => ({
-  ['shadow-small']: props.raised,
-  [props.vertical ? 'divide-y' : 'divide-x']: !props.outlined,
-  ['flex-col']: props.vertical
-}))
+const nonOutlinedClass = props.vertical ? ccButtonGroup.nonOutlinedVertical : ccButtonGroup.nonOutlinedHorizontal
+
+const classes = computed(() => [
+  ccButtonGroup.wrapper,
+  props.raised ? ccButtonGroup.raised : '',
+  props.vertical ? ccButtonGroup.vertical : '',
+  props.outlined ? '' : nonOutlinedClass
+])
 </script>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.50",
+    "@warp-ds/component-classes": "^1.0.0-alpha.51",
     "@warp-ds/uno": "1.0.0-alpha.19",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ devDependencies:
     specifier: ^2.0.2
     version: 2.3.0(vue@3.2.47)
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.50
-    version: 1.0.0-alpha.50
+    specifier: ^1.0.0-alpha.51
+    version: 1.0.0-alpha.51
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1305,8 +1305,8 @@ packages:
       '@vue/server-renderer': 3.2.47(vue@3.2.47)
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.50:
-    resolution: {integrity: sha512-cQgJjsIX4j/ZrVa8UHfyT+LY2D+dXhu0diKAj1zLDT5i1udQn1ja3KFd+tbDigKHj3vIrlobrMS0r1tmx12iSg==}
+  /@warp-ds/component-classes@1.0.0-alpha.51:
+    resolution: {integrity: sha512-BVnw0QY3xU8j3Fie+4yXzKXNZc4MqS2nH0OImdsyTl7N1mdjpe6Ln5wsFlooV+eY/3kAZSKFjFwp9zIx36Nx+Q==}
     dev: true
 
   /@warp-ds/core@1.0.0:

--- a/test/wButtonGroup.test.js
+++ b/test/wButtonGroup.test.js
@@ -25,6 +25,6 @@ describe('button group', () => {
     assert.include(anchor.attributes().href, '#/foo')
     assert.equal(anchor.text(), 'Foo')
     const groupItem = wrapper.getComponent(wButtonGroupItem)
-    assert.include(groupItem.classes(), 'i-border-$gray-300') // providing the outlined prop succeeded
+    assert.include(groupItem.classes(), 'i-border-$color-button-group-border') // providing the outlined prop succeeded
   })
 })

--- a/test/wButtonGroup.test.js
+++ b/test/wButtonGroup.test.js
@@ -25,6 +25,6 @@ describe('button group', () => {
     assert.include(anchor.attributes().href, '#/foo')
     assert.equal(anchor.text(), 'Foo')
     const groupItem = wrapper.getComponent(wButtonGroupItem)
-    assert.include(groupItem.classes(), 'i-border-$color-button-group-border') // providing the outlined prop succeeded
+    assert.include(groupItem.classes(), 'i-border-$color-buttongroup-border') // providing the outlined prop succeeded
   })
 })


### PR DESCRIPTION
This PR adds styling to ButtonGroup based on Warp component classes and respective tokens.
In order to fix issues with border hover and active colors not displaying properly, the styling of borders was moved from ButtonGroup to ButtonGroupItem component.

## non-outlined 
### with selected and hovered items
![Screenshot 2023-05-03 at 15 23 02](https://user-images.githubusercontent.com/41303231/235929895-384f01b5-0a15-4aa2-9462-f6ce488f1bf9.png)
### raised with selected item
![Screenshot 2023-05-03 at 15 25 57](https://user-images.githubusercontent.com/41303231/235929906-9740144d-bbab-4fd1-907b-efea7cfe9192.png)
### vertical with selected hovered item
![Screenshot 2023-05-03 at 15 29 51](https://user-images.githubusercontent.com/41303231/235930462-34dc9291-5075-459d-b06c-c94fe2313b9a.png)

## outlined 
### with selected and hovered items
![Screenshot 2023-05-03 at 15 23 25](https://user-images.githubusercontent.com/41303231/235929899-1c304b8c-e5ee-4615-adf1-52f2f0af61b6.png)
### vertical with selected item
![Screenshot 2023-05-03 at 15 25 43](https://user-images.githubusercontent.com/41303231/235929902-e0b89c74-ebd5-4cce-b5a6-e7cdbf561054.png)
### raised & vertical with selected item
![Screenshot 2023-05-03 at 15 25 47](https://user-images.githubusercontent.com/41303231/235929904-f1bcb03f-b864-4b2f-ba58-3dff8bc68248.png)

## Tori branding:
<img width="209" alt="Screenshot 2023-05-04 at 16 00 59" src="https://user-images.githubusercontent.com/41303231/236230838-9fe435f6-b35e-437b-8dc8-a628ae37c2ab.png">

