### PR TITLE
fix (buttongroup): apply utility tokens from component-classes

### DIFF
--- a/components/button-group/w-button-group-item.vue
+++ b/components/button-group/w-button-group-item.vue
@@ -8,7 +8,8 @@ const vertical = inject('vertical', false);
 
 const outlinedClass = computed(() => [
   ccButtonGroupItem.outlined,
-  vertical.value ? ccButtonGroupItem.outlinedVertical : ccButtonGroupItem.outlinedHorizontal
+  vertical.value ? ccButtonGroupItem.outlinedVertical : ccButtonGroupItem.outlinedHorizontal,
+  props.selected ? ccButtonGroupItem.outlinedSelected : ''
 ]);
 
 const outlineResetClass = computed(() => [vertical.value ? ccButtonGroupItem.outlinedVerticalResets : ccButtonGroupItem.outlinedHorizontalResets])

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.51",
+    "@warp-ds/component-classes": "^1.0.0-alpha.56",
     "@warp-ds/uno": "1.0.0-alpha.19",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ devDependencies:
     specifier: ^2.0.2
     version: 2.3.0(vue@3.2.47)
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.51
-    version: 1.0.0-alpha.51
+    specifier: ^1.0.0-alpha.56
+    version: 1.0.0-alpha.56
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1305,8 +1305,8 @@ packages:
       '@vue/server-renderer': 3.2.47(vue@3.2.47)
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.51:
-    resolution: {integrity: sha512-BVnw0QY3xU8j3Fie+4yXzKXNZc4MqS2nH0OImdsyTl7N1mdjpe6Ln5wsFlooV+eY/3kAZSKFjFwp9zIx36Nx+Q==}
+  /@warp-ds/component-classes@1.0.0-alpha.56:
+    resolution: {integrity: sha512-a4yR3POi+2xCQHM/qkimJbSYqz5HfzxFjKxuEypV6B/Wu+0u+lmRn9hWQUc0yPQ6DhbeGTwN0A0X2Rb4ZewbEA==}
     dev: true
 
   /@warp-ds/core@1.0.0:

--- a/test/wButtonGroup.test.js
+++ b/test/wButtonGroup.test.js
@@ -25,6 +25,6 @@ describe('button group', () => {
     assert.include(anchor.attributes().href, '#/foo')
     assert.equal(anchor.text(), 'Foo')
     const groupItem = wrapper.getComponent(wButtonGroupItem)
-    assert.include(groupItem.classes(), 'i-border-$color-buttongroup-border') // providing the outlined prop succeeded
+    assert.include(groupItem.classes(), 'i-border-$color-buttongroup-utility-border') // providing the outlined prop succeeded
   })
 })


### PR DESCRIPTION
Vue's ButtonGroup component used to have grey utility-like colors in Fabric, which should be the same in Warp.
Additionally, a small bug was fixed where selected non-outlined item got an active dark-grey border color.

<img width="148" alt="Screenshot 2023-05-08 at 13 26 28" src="https://user-images.githubusercontent.com/41303231/236812193-4a81adf3-d185-41d7-812a-33ca69dc25de.png">
<img width="280" alt="Screenshot 2023-05-08 at 13 12 15" src="https://user-images.githubusercontent.com/41303231/236810082-8a069179-bdc4-4f83-af04-98cda203bed7.png">
<img width="120" alt="Screenshot 2023-05-08 at 13 12 27" src="https://user-images.githubusercontent.com/41303231/236810084-1a9b4b16-fbcb-4502-9718-be17fbc3af02.png">
<img width="138" alt="Screenshot 2023-05-08 at 13 12 32" src="https://user-images.githubusercontent.com/41303231/236810085-fbe72ccc-12a8-42c7-b491-6cfa6eb95759.png">
