### PR TITLE
fix: use radioChecked class

### DIFF
--- a/components/generic/w-toggle-item.vue
+++ b/components/generic/w-toggle-item.vue
@@ -43,7 +43,7 @@ const labelClasses = computed(() => (p.labelClass || {
   [ccToggle.focusable]: !p.radioButton,
   [ccToggle.noContent]: !p.radioButton,
   [ccToggle.labelRadioColors] : isRadio.value && !p.radioButton,
-  [ccToggle.radio]: isRadio.value,
+  [`${ccToggle.radio} ${p.disabled ? '' : ccToggle.radioChecked}`]: isRadio.value,
   [ccToggle.radioInvalid]: isRadio.value && p.invalid,
   [ccToggle.checkboxInvalid]: isCheckbox.value && p.invalid,
   [`${ccToggle.checkbox} ${ccToggle.labelCheckboxColors} ${ccToggle.icon} ${p.disabled ? '' : ccToggle.checkboxChecked}`]: isCheckbox.value,


### PR DESCRIPTION
Before|After
---|---
<img width="459" alt="image" src="https://github.com/warp-ds/vue/assets/37986637/027f881b-3af1-4560-b342-c417c66da544">|<img width="364" alt="image" src="https://github.com/warp-ds/vue/assets/37986637/78fbd661-ef28-4ce5-acbd-f0cd9c273d5c">

Class fix here