### PR TITLE
fix: add classes to card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.0.0-alpha.22](https://github.com/warp-ds/vue/compare/v1.0.0-alpha.21...v1.0.0-alpha.22) (2023-05-11)
+
+
+### Bug Fixes
+
+* add classes to clickable ([#29](https://github.com/warp-ds/vue/issues/29)) ([c220593](https://github.com/warp-ds/vue/commit/c2205937b67289c7b96a4ca972cc76e6492c90ed))
+
 # [1.0.0-alpha.21](https://github.com/warp-ds/vue/compare/v1.0.0-alpha.20...v1.0.0-alpha.21) (2023-05-10)
 
 

--- a/components/card/w-card.vue
+++ b/components/card/w-card.vue
@@ -1,3 +1,26 @@
+<script setup>
+import { card as ccCard } from '@warp-ds/component-classes';
+import { computed } from 'vue';
+
+const props = defineProps({
+  as: { type: String, default: 'div' },
+  selected: Boolean,
+  flat: Boolean
+})
+
+const outerClasses = computed(() => ({
+  [ccCard.card]: true,
+  [ccCard.cardShadow]: !props.flat,
+  [ccCard.cardSelected]: props.selected,
+  [ccCard.cardFlat]: props.flat,
+  [props.selected ? ccCard.cardFlatSelected : ccCard.cardFlatUnselected]: props.flat
+}))
+const innerClasses = computed(() => ({
+  [ccCard.cardOutline]: true,
+  [props.selected ? ccCard.cardOutlineSelected : ccCard.cardOutlineUnselected]: true
+}))
+</script>
+
 <template>
   <component :is="as" :class="outerClasses">
     <div v-if="!flat" :class="innerClasses" />
@@ -7,27 +30,4 @@
 
 <script>
 export default { name: 'wCard' }
-</script>
-
-<script setup>
-import { card as c } from '@fabric-ds/css/component-classes'
-import { computed } from 'vue'
-
-const props = defineProps({
-  as: { type: String, default: 'div' },
-  selected: Boolean,
-  flat: Boolean
-})
-
-const outerClasses = computed(() => ({
-  [c.card]: true,
-  [c.cardShadow]: !props.flat,
-  [c.cardSelected]: props.selected,
-  [c.cardFlat]: props.flat,
-  [props.selected ? c.cardFlatSelected : c.cardFlatUnselected]: props.flat
-}))
-const innerClasses = computed(() => ({
-  [c.cardOutline]: true,
-  [props.selected ? c.cardOutlineSelected : c.cardOutlineUnselected]: true
-}))
 </script>

--- a/components/generic/w-clickable.vue
+++ b/components/generic/w-clickable.vue
@@ -1,12 +1,3 @@
-<template>
-  <w-toggle-item v-if="radio || checkbox" class="focus-ring focus-ring-inset" :class="clickableClasses" :type="type" :label-class="labelClasses" v-bind="$attrs">
-    <slot />
-  </w-toggle-item>
-  <component v-else :is="href ? 'a' : 'button'" class="focus-ring focus-ring-inset" :class="labelClasses" :href="href" :type="href ? undefined : ($attrs.type || 'button')">
-    <span :class="clickableClasses" aria-hidden="true" />
-    <slot />
-  </component>
-</template>
 
 <script setup>
 import { computed } from 'vue';
@@ -22,14 +13,25 @@ const props = defineProps({
 const type = computed(() => props.radio ? 'radio' : 'checkbox');
 
 const clickableClasses = computed(() => ({
-  [ccClickable.clickable]: props.label,
+  ['focus:focusable:focus focus-visible:focusable:focus-visible not-focus-visible:focusable:focus:not(:focus-visible) focusable-inset']: true,
+  [ccClickable.clickable]: true,
 }));
 const labelClasses = computed(() => ({
+  ['focus:focusable:focus focus-visible:focusable:focus-visible not-focus-visible:focusable:focus:not(:focus-visible) focusable-inset']: true,
   [ccClickable.label]: props.label,
 }));
 
 </script>
 
+<template>
+  <w-toggle-item v-if="radio || checkbox" :class="clickableClasses" :type="type" :label-class="labelClasses" v-bind="$attrs">
+    <slot />
+  </w-toggle-item>
+  <component v-else :is="href ? 'a' : 'button'" :class="labelClasses" :href="href" :type="href ? undefined : ($attrs.type || 'button')">
+    <span :class="clickableClasses" aria-hidden="true" />
+    <slot />
+  </component>
+</template>
 
 <script>
 export default { name: 'wClickable' };

--- a/components/generic/w-dead-toggle.vue
+++ b/components/generic/w-dead-toggle.vue
@@ -1,22 +1,37 @@
+<script setup>
+import { toggle as ccToggle } from '@warp-ds/component-classes';
+import wToggleItem from './w-toggle-item.vue';
+import { computed } from 'vue';
+
+const props = defineProps({
+  radio: Boolean,
+  checkbox: Boolean,
+})
+const type = computed(() => props.radio ? 'radio' : 'checkbox');
+
+const labelClasses = computed(() => ({
+    [ccToggle.label]: true,
+    [ccToggle.focusable]: true,
+    [ccToggle.noContent]: true,
+    [ccToggle.deadToggleLabel]: true,
+    [`${ccToggle.radio} ${ccToggle.labelRadioBorder} ${ccToggle.radioChecked}`]: props.radio,
+    [`${ccToggle.checkbox} ${ccToggle.labelCheckboxBorder} ${ccToggle.checkboxChecked}`]: props.checkbox,
+    [ccToggle.icon]: props.checkbox,
+  }));
+
+  const wrapperClasses = {
+    [ccToggle.wrapper]: true,
+    [ccToggle.deadToggleWrapper]: true,
+  };
+
+</script>
+
 <template>
-  <div class="input-toggle h-20 w-20 pointer-events-none" aria-hidden="true">
-    <w-toggle-item class="hidden" label-class="-mt-2" :type="type" v-bind="$attrs" />
+  <div :class="wrapperClasses" aria-hidden="true">
+    <w-toggle-item :class="ccToggle.deadToggleInput" :label-class="labelClasses" :type="type" v-bind="$attrs" />
   </div>
 </template>
 
 <script>
-import wToggleItem from './w-toggle-item.vue'
-import { computed } from 'vue'
-
-export default {
-  name: 'wDeadToggle',
-  components: { wToggleItem },
-  props: {
-    radio: Boolean,
-    checkbox: Boolean,
-  },
-  setup: (props) => ({
-    type: computed(() => props.radio ? 'radio' : 'checkbox')
-  })
-}
+export default { name: 'wDeadToggle' };
 </script>

--- a/components/generic/w-toggle-item.vue
+++ b/components/generic/w-toggle-item.vue
@@ -1,19 +1,3 @@
-<template>
-  <input 
-    :id="id" 
-    v-model="model" 
-    :type="type"
-    :radioButton="radioButton"
-    :disabled="disabled"
-    :invalid="invalid"
-    :equalWidth="equalWidth"
-    v-bind="$attrs" 
-    :class="[inputClasses]" 
-  />
-  <label v-if="label" :for="id" v-html="label" :class="labelClasses" />
-  <label v-else :for="id" :class="labelClasses"><slot /></label>
-</template>
-
 <script setup>
 import { computed } from 'vue';
 import { id as uniqueId } from '#util';
@@ -51,12 +35,28 @@ const labelClasses = computed(() => (p.labelClass || {
   [ccToggle.radioButtonsLabelSmall]: p.small,
 }));
 const inputClasses = {
-  [p.class ? `${p.class} ${ccToggle.input}` : ccToggle.input]: true,
+  [ccToggle.input]: true,
+  [p.class || ccToggle.a11y]: true,
 };
 
 </script>
 
+<template>
+  <input 
+    :id="id" 
+    v-model="model" 
+    :type="type"
+    :radioButton="radioButton"
+    :disabled="disabled"
+    :invalid="invalid"
+    :equalWidth="equalWidth"
+    v-bind="$attrs" 
+    :class="[inputClasses]" 
+  />
+  <label v-if="label" :for="id" v-html="label" :class="labelClasses" />
+  <label v-else :for="id" :class="labelClasses"><slot /></label>
+</template>
+
 <script>
 export default { name: 'wToggleItem' };
-
 </script>

--- a/dev/pages/Card.vue
+++ b/dev/pages/Card.vue
@@ -4,12 +4,76 @@ import { wCard, wDeadToggle, wClickable, wTag } from '#components'
 
 const selected = ref(false)
 const foo = ref('')
+
+const checkModel = ref(false)
+const radioModel = ref('')
+
 </script>
 
 <template>
   <div>
     <component-title title="Card" />
 
+    <token>
+      <div class="space-y-32 md:space-y-0 md:grid grid-cols-3 gap-32">
+        <w-card :selected="selected">
+          <img class="h-128 w-full object-cover" src="https://source.unsplash.com/random/400x400" />
+          <p class="absolute top-12 left-12 bg-aqua-200 text-aqua-900 p-4 rounded-4 text-12">Ukens bolig</p>
+          <div class="p-16">
+            <p class="text-12 text-gray-300">DNB Eiendom</p>
+            <p><w-clickable @click="selected = !selected" class="text-left">Stilfull og gjennomgående 3-roms m/balkong. Oppusset i 2019. Inkl. bl.a. vv/fyring.</w-clickable></p>
+            <p class="text-14 text-gray-400 mb-4">Bøgata 25C, 0655 Oslo</p>
+            <p class="font-bold my-8">52 m<span style="font-size: 10px; vertical-align: super;">2</span> Totalpris: 4 869 039 kr</p>
+            <p class="text-14 text-gray-400 mb-0">Eier (Selveier) <span class="text-gray-200">•</span> Leilighet <span class="text-gray-200">•</span> 2 soverom</p>
+          </div>
+        </w-card>
+        <w-card :selected="selected">
+          <img class="h-128 w-full object-cover" src="https://source.unsplash.com/random/400x402" />
+          <p class="absolute top-12 left-12 bg-aqua-200 text-aqua-900 p-4 rounded-4 text-12">Ukens bolig</p>
+          <div class="p-16">
+            <p class="text-12 text-gray-300">DNB Eiendom</p>
+            <p><w-clickable @click="selected = !selected" class="text-left">Stilfull og gjennomgående 3-roms m/balkong. Oppusset i 2019. Inkl. bl.a. vv/fyring.</w-clickable></p>
+            <p class="text-14 text-gray-400 mb-4">Bøgata 25C, 0655 Oslo</p>
+            <p class="font-bold my-8">52 m<span style="font-size: 10px; vertical-align: super;">2</span> Totalpris: 4 869 039 kr</p>
+            <p class="text-14 text-gray-400 mb-0">Eier (Selveier) <span class="text-gray-200">•</span> Leilighet <span class="text-gray-200">•</span> 2 soverom</p>
+          </div>
+        </w-card>
+        <w-card :selected="selected">
+          <img class="h-128 w-full object-cover" src="https://source.unsplash.com/random/400x404" />
+          <p class="absolute top-12 left-12 bg-aqua-200 text-aqua-900 p-4 rounded-4 text-12">Ukens bolig</p>
+          <div class="p-16">
+            <p class="text-12 text-gray-300">DNB Eiendom</p>
+            <p><w-clickable @click="selected = !selected" class="text-left">Stilfull og gjennomgående 3-roms m/balkong. Oppusset i 2019. Inkl. bl.a. vv/fyring.</w-clickable></p>
+            <p class="text-14 text-gray-400 mb-4">Bøgata 25C, 0655 Oslo</p>
+            <p class="font-bold my-8">52 m<span style="font-size: 10px; vertical-align: super;">2</span> Totalpris: 4 869 039 kr</p>
+            <p class="text-14 text-gray-400 mb-0">Eier (Selveier) <span class="text-gray-200">•</span> Leilighet <span class="text-gray-200">•</span> 2 soverom</p>
+          </div>
+        
+        </w-card>
+      </div>
+
+      <w-card :selected="checkModel" class="mt-32 w-max">
+        <div class="p-24 flex">
+          <w-dead-toggle checkbox v-model="checkModel" :value="true" />
+          <w-clickable checkbox :value="true" v-model="checkModel" label-class="ml-12 text-16">Check in a card</w-clickable>
+        </div>
+      </w-card>
+
+      <div class="flex gap-32 mt-32">
+        <w-card :selected="radioModel === 'foo'" class="w-max">
+          <div class="p-24 flex">
+            <w-dead-toggle radio v-model="radioModel" value="foo" />
+            <w-clickable radio value="foo" v-model="radioModel" label-class="ml-12" name="radio-group">Radio in a card - A</w-clickable>
+          </div>
+        </w-card>
+        <w-card :selected="radioModel === 'bar'" class="w-max">
+          <div class="p-24 flex">
+            <w-dead-toggle radio v-model="radioModel" value="bar" />
+            <w-clickable radio value="bar" v-model="radioModel" label-class="ml-12" name="radio-group">Radio in a card - B</w-clickable>
+          </div>
+        </w-card>
+      </div>
+    </token>
     <token>
       <div class="w-1/2">
         <w-card :selected="selected">

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.61",
+    "@warp-ds/component-classes": "^1.0.0-alpha.66",
     "@warp-ds/uno": "1.0.0-alpha.22",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/vue",
   "repository": "git@github.com:warp-ds/vue.git",
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0-alpha.22",
   "description": "Warp components for Vue 3",
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ devDependencies:
     specifier: ^2.0.2
     version: 2.3.0(vue@3.2.47)
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.61
-    version: 1.0.0-alpha.61
+    specifier: ^1.0.0-alpha.66
+    version: 1.0.0-alpha.66
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1305,8 +1305,8 @@ packages:
       '@vue/server-renderer': 3.2.47(vue@3.2.47)
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.61:
-    resolution: {integrity: sha512-VcijhxA2bmYLbmfb9IdSXeJjDx7LuAMas7hP7zWhpbXyhyi7OjGfezKSONN3phjaY4puQbzJNqkNmQ8Ajh1IRw==}
+  /@warp-ds/component-classes@1.0.0-alpha.66:
+    resolution: {integrity: sha512-vTMAlXPrihls9Vol2ovBsErshGfNI0dq3vqjbKCqS5triFllCVp18pFhLeDNsP2VXzf641CUAFSpabG6Vg7xcQ==}
     dev: true
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
Extra styles have been migrated from https://github.com/fabric-ds/css/blob/next/src/components/card.css

![image](https://github.com/warp-ds/vue/assets/37986637/1a9f31bf-a690-458c-a100-d299d8e54bca)

~QUESTION 1: `shadow-none` do we need support for this one? We are supposed to remove the shadow when we hover on the active card.~ not applicable anymore
QUESTION 2: https://github.com/fabric-ds/css/blob/next/src/components/card.css#L23 can't find this styling somewhere in the code, does anyone else know when I can look?