### PR TITLE
Warpify tabs

### DIFF
--- a/components/tabs/w-tab-panel.vue
+++ b/components/tabs/w-tab-panel.vue
@@ -1,17 +1,23 @@
+<script setup>
+const props = defineProps({
+  name: {
+    type: String,
+    required: true,
+  },
+});
+</script>
+
 <template>
-  <div tabindex="-1" role="tabpanel" :id="`warp-tabpanel-${name}`" :aria-labelledby="`warp-tab-${name}`">
+  <div
+    tabindex="-1"
+    role="tabpanel"
+    :id="`warp-tabpanel-${name}`"
+    :aria-labelledby="`warp-tab-${name}`"
+  >
     <slot />
   </div>
 </template>
 
 <script>
-export default {
-  name: 'wTabPanel',
-  props: {
-    name: {
-      type: String,
-      required: true
-    }
-  }
-}
+export default { name: 'wTabPanel' };
 </script>

--- a/components/tabs/w-tab.vue
+++ b/components/tabs/w-tab.vue
@@ -1,5 +1,60 @@
+<script setup>
+import { tab as ccTab } from '@warp-ds/component-classes';
+import { inject, computed, onBeforeUnmount } from 'vue';
+
+const props = defineProps({
+  label: String,
+  name: {
+    type: String,
+    required: true,
+  },
+});
+
+const controller = inject('tab-controller');
+const activeTab = inject('activeTab');
+const contained = inject('contained');
+
+const isActive = computed(() => props.name === activeTab.value);
+const setActive = () => (activeTab.value = props.name);
+
+controller.registerTab(props.name);
+onBeforeUnmount(() => {
+  controller?.unregisterTab?.(props.name);
+});
+
+const tabClasses = computed(() => ({
+  [ccTab.tab]: true,
+  ['active-tab']: isActive.value,
+  [ccTab.tabActive]: isActive.value,
+}));
+
+const iconClasses = computed(() => ({
+  [ccTab.icon]: true,
+  [ccTab.iconUnderlined]: true,
+  [isActive.value
+    ? ccTab.iconUnderlinedActive
+    : ccTab.iconUnderlinedInactive]: true,
+}));
+
+const contentClasses = computed(() => ({
+  [ccTab.contentUnderlined]: true,
+  [isActive.value
+    ? ccTab.contentUnderlinedActive
+    : ccTab.contentUnderlinedInactive]: !contained.value,
+}));
+</script>
+
 <template>
-  <button :class="tabClasses" @click="setActive" role="tab" :id="`warp-tab-${name}`" :aria-selected="isActive" :aria-controls="isActive ? `warp-tabpanel-${name}` : undefined" :tabindex="isActive ? 0 : -1" @keydown="onKeydown">
+  <button
+    :class="tabClasses"
+    @click="setActive"
+    role="tab"
+    :id="`warp-tab-${name}`"
+    :aria-selected="isActive"
+    :aria-controls="isActive ? `warp-tabpanel-${name}` : undefined"
+    :tabindex="isActive ? 0 : -1"
+    @keydown="onKeydown"
+  >
     <span v-if="$slots.default" :class="iconClasses">
       <slot />
     </span>
@@ -11,50 +66,5 @@
 </template>
 
 <script>
-import { tab as c } from '@fabric-ds/css/component-classes'
-import { inject, computed, onBeforeUnmount } from 'vue'
-
-export default {
-  name: 'wTab',
-  props: {
-    label: String,
-    name: {
-      type: String,
-      required: true
-    }
-  },
-  setup(props) {
-    const controller = inject('tab-controller')
-    const activeTab = inject('activeTab')
-    const contained = inject('contained')
-    const isActive = computed(() => props.name === activeTab.value)
-    const setActive = () => activeTab.value = props.name
-
-    controller.registerTab(props.name)
-    onBeforeUnmount(() => {
-      controller?.unregisterTab?.(props.name)
-    })
-
-    const contentClasses = computed(() => ({
-      [c.contentUnderlined]: !contained.value,
-      [isActive.value ? c.contentUnderlinedActive : c.contentUnderlinedInactive]: !contained.value,
-      [c.contentContainedActive]: contained.value && isActive.value,
-    }))
-
-    const iconClasses = computed(() => ({
-      [c.icon]: true,
-      [c.iconUnderlined]: !contained.value,
-      [isActive.value ? c.iconUnderlinedActive : c.iconUnderlinedInactive]: !contained.value
-    }))
-
-    const tabClasses = computed(() => ({
-      [c.tab]: true,
-      [c.tabActive]: isActive.value,
-      [c.tabContained]: contained.value,
-      [c.tabContainedActive]: contained.value && isActive.value
-    }))
-
-    return { isActive, setActive, contentClasses, iconClasses, tabClasses, onKeydown: controller.onKeydown }
-  }
-}
+export default { name: 'wTab' };
 </script>

--- a/components/tabs/w-tab.vue
+++ b/components/tabs/w-tab.vue
@@ -12,7 +12,6 @@ const props = defineProps({
 
 const controller = inject('tab-controller');
 const activeTab = inject('activeTab');
-const contained = inject('contained');
 
 const isActive = computed(() => props.name === activeTab.value);
 const setActive = () => (activeTab.value = props.name);
@@ -40,7 +39,7 @@ const contentClasses = computed(() => ({
   [ccTab.contentUnderlined]: true,
   [isActive.value
     ? ccTab.contentUnderlinedActive
-    : ccTab.contentUnderlinedInactive]: !contained.value,
+    : ccTab.contentUnderlinedInactive]: true,
 }));
 </script>
 

--- a/components/tabs/w-tabs.vue
+++ b/components/tabs/w-tabs.vue
@@ -1,69 +1,112 @@
+<script setup>
+import { tabs as ccTabs } from '@warp-ds/component-classes';
+import {
+  provide,
+  computed,
+  ref,
+  toRef,
+  watch,
+  nextTick,
+  onMounted,
+  Fragment,
+  useSlots,
+} from 'vue';
+import { modelProps, createModel } from 'create-v-model';
+import debounce from 'femtobounce';
+import { useKeydownHandler } from './util';
+
+const props = defineProps({
+  contained: Boolean,
+  ...modelProps(),
+});
+
+const slots = useSlots();
+
+const useGetActiveTab = (tabContainer) => () =>
+  tabContainer.value?.querySelector('.active-tab');
+const getChildren = (slot) =>
+  slot[0].type === Fragment ? slot[0].children : slot;
+
+// Todo: Make a better solution
+const colsClassName = [
+  'grid-cols-1',
+  'grid-cols-2',
+  'grid-cols-3',
+  'grid-cols-4',
+  'grid-cols-5',
+  'grid-cols-6',
+  'grid-cols-7',
+  'grid-cols-8',
+  'grid-cols-9',
+];
+
+const activeTab = createModel({ props });
+const tabContainer = ref(null);
+const wunderbar = ref(null);
+const tabs = ref([]);
+const registerTab = (tab) => tabs.value.push(tab);
+const unregisterTab = (tab) => {
+  const idx = tabs.value.indexOf(tab);
+  if (idx !== -1) tabs.value.splice(idx, 1);
+};
+const gridsClassname = computed(() => colsClassName[tabs.value.length - 1]);
+// SSR doesn't complete the tab-registry lifecycle before render, so we just count children and use that when numberOfTabs is 0
+const slotFallback = computed(
+  () => colsClassName[getChildren(slots.default()).length - 1]
+);
+const getActiveTab = useGetActiveTab(tabContainer);
+const focusActive = () => getActiveTab()?.focus();
+
+provide('tab-controller', {
+  registerTab,
+  unregisterTab,
+  onKeydown: useKeydownHandler({ tabs, activeTab, focusActive }),
+});
+provide('activeTab', activeTab);
+provide('contained', toRef(props, 'contained'));
+
+const updateWunderbar = async () => {
+  if (props.contained) return;
+  await nextTick();
+  try {
+    const activeEl = getActiveTab();
+    const { left: parentLeft } = tabContainer.value.getBoundingClientRect();
+    const { left, width } = activeEl.getBoundingClientRect();
+    wunderbar.value.style.left = left - parentLeft + 'px';
+    wunderbar.value.style.width = width + 'px';
+  } catch (err) {
+    console.warn('Problem updating tabs', err);
+  }
+};
+
+onMounted(() => {
+  watch(activeTab, updateWunderbar, { immediate: true });
+  watch(() => props.contained, updateWunderbar);
+  const resizeHandler = new ResizeObserver(debounce(updateWunderbar, 100));
+  resizeHandler.observe(tabContainer.value);
+});
+</script>
+
 <template>
-  <nav :class="{ [contained ? c.wrapperContained : c.wrapperUnderlined]: true }">
-    <div :class="{ [c.tabContainer]: true, [`grid-cols-${numberOfTabs || slotFallback}`]: true }" ref="tabContainer" role="tablist">
+  <nav
+    :class="{
+      [ccTabs.wrapperUnderlined]: true,
+    }"
+  >
+    <div
+      :class="{
+        [ccTabs.tabContainer]: true,
+        [gridsClassname || slotFallback]: true,
+      }"
+      ref="tabContainer"
+      role="tablist"
+    >
       <slot />
-      <span v-if="!contained" :class="c.wunderbar" ref="wunderbar" />
+      <span v-if="!contained" :class="ccTabs.wunderbar" ref="wunderbar" />
     </div>
   </nav>
 </template>
 
 <script>
-import { tabs as c } from '@fabric-ds/css/component-classes'
-import { provide, computed, ref, toRef, watch, nextTick, onMounted, Fragment } from 'vue'
-import { modelProps, createModel } from 'create-v-model'
-import debounce from 'femtobounce'
-import { useKeydownHandler } from './util'
-
-const useGetActiveTab = (tabContainer) => () => tabContainer.value?.querySelector('.active-tab')
-const getChildren = slot => slot[0].type === Fragment ? slot[0].children : slot
-
-export default {
-  name: 'wTabs',
-  props: {
-    contained: Boolean,
-    ...modelProps()
-  },
-  setup(props, { slots }) {
-    const activeTab = createModel({ props })
-    const tabContainer = ref(null)
-    const wunderbar = ref(null)
-    const tabs = ref([])
-    const registerTab = (tab) => tabs.value.push(tab)
-    const unregisterTab = (tab) => {
-      const idx = tabs.value.indexOf(tab)
-      if (idx !== -1) tabs.value.splice(idx, 1)
-    }
-    const numberOfTabs = computed(() => tabs.value.length)
-    // SSR doesn't complete the tab-registry lifecycle before render, so we just count children and use that when numberOfTabs is 0
-    const slotFallback = computed(() => getChildren(slots.default()).length)
-    const getActiveTab = useGetActiveTab(tabContainer)
-    const focusActive = () => getActiveTab()?.focus()
-    provide('tab-controller', { registerTab, unregisterTab, onKeydown: useKeydownHandler({ tabs, activeTab, focusActive }) })
-    provide('activeTab', activeTab)
-    provide('contained', toRef(props, 'contained'))
-
-    const updateWunderbar = async () => {
-      if (props.contained) return
-      await nextTick()
-      try {
-        const activeEl = getActiveTab()
-        const { left: parentLeft } = tabContainer.value.getBoundingClientRect()
-        const { left, width } = activeEl.getBoundingClientRect()
-        wunderbar.value.style.left = (left - parentLeft) + 'px'
-        wunderbar.value.style.width = width + 'px'
-      } catch (err) {
-        console.warn('Problem updating tabs', err)
-      }
-    }
-
-    onMounted(() => {
-      watch(activeTab, updateWunderbar, { immediate: true })
-      watch(() => props.contained, updateWunderbar)
-      const resizeHandler = new ResizeObserver(debounce(updateWunderbar, 100))
-      resizeHandler.observe(tabContainer.value)
-    })
-
-    return { c, tabContainer, wunderbar, numberOfTabs, slotFallback }
-  }
-}
+export default { name: 'wTabs' };
 </script>

--- a/dev/pages/Tabs.vue
+++ b/dev/pages/Tabs.vue
@@ -1,30 +1,32 @@
 <script setup>
-import { wTabs, wTab, wTabPanel } from '#components'
-import { radio, useIsActive } from '#dev-util'
-import { ref, reactive, h } from 'vue'
+import { wTabs, wTab, wTabPanel } from '#components';
+import { radio, useIsActive } from '#dev-util';
+import { ref, reactive, h } from 'vue';
 
 const Stars = {
   name: 'stars-svg',
-  render: () => h('div', { innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6.322 10.1l-.863-.45a.49.49 0 00-.453 0L2.991 10.7a.491.491 0 01-.51-.034.474.474 0 01-.193-.466l.387-2.246a.471.471 0 00-.137-.419L.894 5.944a.472.472 0 01.029-.704.48.48 0 01.24-.106l2.263-.327a.483.483 0 00.364-.262L4.8 2.511a.484.484 0 01.434-.267M17.678 10.1l.863-.451a.49.49 0 01.453 0L21.01 10.7a.491.491 0 00.51-.034.474.474 0 00.193-.466l-.387-2.246a.472.472 0 01.137-.419l1.644-1.595a.471.471 0 00-.028-.704.48.48 0 00-.24-.106l-2.264-.327a.483.483 0 01-.364-.262l-1.01-2.03a.483.483 0 00-.434-.267M3 14h18M3 22h18M3 18h14M11.566 1.017a.486.486 0 01.868 0l1.01 2.034a.483.483 0 00.362.262l2.264.327a.48.48 0 01.39.323.47.47 0 01-.122.487L14.7 6.044a.473.473 0 00-.138.419l.388 2.247a.473.473 0 01-.194.465.487.487 0 01-.509.035l-2.02-1.054a.482.482 0 00-.453 0L9.758 9.21a.487.487 0 01-.673-.24.474.474 0 01-.03-.26l.388-2.247a.473.473 0 00-.138-.419L7.662 4.45a.47.47 0 01.028-.704.481.481 0 01.24-.106l2.264-.327a.483.483 0 00.363-.262l1.01-2.034z"></path></svg>' })
-}
+  render: () =>
+    h('div', {
+      innerHTML:
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6.322 10.1l-.863-.45a.49.49 0 00-.453 0L2.991 10.7a.491.491 0 01-.51-.034.474.474 0 01-.193-.466l.387-2.246a.471.471 0 00-.137-.419L.894 5.944a.472.472 0 01.029-.704.48.48 0 01.24-.106l2.263-.327a.483.483 0 00.364-.262L4.8 2.511a.484.484 0 01.434-.267M17.678 10.1l.863-.451a.49.49 0 01.453 0L21.01 10.7a.491.491 0 00.51-.034.474.474 0 00.193-.466l-.387-2.246a.472.472 0 01.137-.419l1.644-1.595a.471.471 0 00-.028-.704.48.48 0 00-.24-.106l-2.264-.327a.483.483 0 01-.364-.262l-1.01-2.03a.483.483 0 00-.434-.267M3 14h18M3 22h18M3 18h14M11.566 1.017a.486.486 0 01.868 0l1.01 2.034a.483.483 0 00.362.262l2.264.327a.48.48 0 01.39.323.47.47 0 01-.122.487L14.7 6.044a.473.473 0 00-.138.419l.388 2.247a.473.473 0 01-.194.465.487.487 0 01-.509.035l-2.02-1.054a.482.482 0 00-.453 0L9.758 9.21a.487.487 0 01-.673-.24.474.474 0 01-.03-.26l.388-2.247a.473.473 0 00-.138-.419L7.662 4.45a.47.47 0 01.028-.704.481.481 0 01.24-.106l2.264-.327a.483.483 0 00.363-.262l1.01-2.034z"></path></svg>',
+    }),
+};
 
-const model = ref('home')
+const model = ref('home');
 
-const type = reactive({ active: 'Open' })
-const active = useIsActive(type)
+const type = reactive({ active: 'Open' });
+const active = useIsActive(type);
 const typeControls = [
   { name: 'Open', radio },
   { name: 'Contained', radio },
-]
-
+];
 </script>
 
 <template>
   <div>
     <component-title title="Tabs" />
-
     <token :state="[model, type]">
-      <w-tabs v-model="model" :contained="active('Contained')">
+      <w-tabs v-model="model">
         <w-tab label="Home" name="home">
           <stars />
         </w-tab>
@@ -35,14 +37,22 @@ const typeControls = [
           <stars />
         </w-tab>
       </w-tabs>
-      <div :class="{ 'bg-aqua-50 p-24 last-child:mb-0': active('Contained'), 'mb-16': !active('Contained') }">
-        <w-tab-panel name="home" v-if="model === 'home'"><h3 class="mb-0">Welcome home!</h3></w-tab-panel>
-        <w-tab-panel name="car" v-if="model === 'car'"><h3 class="mb-0">I am a car page</h3></w-tab-panel>
-        <w-tab-panel name="motorcycle" v-if="model === 'motorcycle'"><h3 class="mb-0">Something something two wheels</h3></w-tab-panel>
+      <div
+        :class="{
+          'bg-aqua-50 p-24 last-child:mb-0': active('Contained'),
+          'mb-16': !active('Contained'),
+        }"
+      >
+        <w-tab-panel name="home" v-if="model === 'home'"
+          ><h3 class="mb-0">Welcome home!</h3></w-tab-panel
+        >
+        <w-tab-panel name="car" v-if="model === 'car'"
+          ><h3 class="mb-0">I am a car page</h3></w-tab-panel
+        >
+        <w-tab-panel name="motorcycle" v-if="model === 'motorcycle'"
+          ><h3 class="mb-0">Something something two wheels</h3></w-tab-panel
+        >
       </div>
     </token>
-    <demo-controls>
-      <demo-control label="Type" :controls="typeControls" :state="type" />
-    </demo-controls>
   </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vue/test-utils": "^2.0.2",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.62",
+    "@warp-ds/component-classes": "^1.0.0-alpha.70",
     "@warp-ds/uno": "1.0.0-alpha.23",
     "cleave-lite": "^1.0.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ devDependencies:
     specifier: ^2.0.2
     version: 2.3.0(vue@3.2.47)
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.62
-    version: 1.0.0-alpha.63
+    specifier: ^1.0.0-alpha.70
+    version: 1.0.0-alpha.70
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1303,8 +1303,8 @@ packages:
       '@vue/server-renderer': 3.2.47(vue@3.2.47)
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.63:
-    resolution: {integrity: sha512-99SKJm9jrcN9fURoOR8KNGi5S7YmsrPGlgNc0blXSuAOLiWy8MYeslMVxU6hGS/b//FTHBbFpOMzm7YihNKnug==}
+  /@warp-ds/component-classes@1.0.0-alpha.70:
+    resolution: {integrity: sha512-YLtjeaX84ymTauuQcZCBkaoxJCaPnZu3834iCW5odUeUXJbPrEEybZdHvjYZ8w+fvFoamNTc2N8xvWMnPnoThA==}
     dev: true
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
This PR includes:

Warpify Tabs
Remove contained as an option for `tabs`: This decision was made by design while no/very few teams are currently using it and it's not part of the current and future design.
Style changes according to new design: e.g. grey border on hover, no underline on hover
Temporary solution for handling the number of grid columns: adding classes dynamically causes issues as it prevents the CSS class to load properly from the drive