### PR TITLE
fix: focusable is added to the component classes

### DIFF
--- a/components/generic/w-clickable.vue
+++ b/components/generic/w-clickable.vue
@@ -11,24 +11,18 @@ const props = defineProps({
   checkbox: Boolean
 });
 const type = computed(() => props.radio ? 'radio' : 'checkbox');
-
-const clickableClasses = computed(() => ({
-  ['focus:focusable:focus focus-visible:focusable:focus-visible not-focus-visible:focusable:focus:not(:focus-visible) focusable-inset']: true,
-  [ccClickable.clickable]: true,
-}));
 const labelClasses = computed(() => ({
-  ['focus:focusable:focus focus-visible:focusable:focus-visible not-focus-visible:focusable:focus:not(:focus-visible) focusable-inset']: true,
   [ccClickable.label]: props.label,
 }));
 
 </script>
 
 <template>
-  <w-toggle-item v-if="radio || checkbox" :class="clickableClasses" :type="type" :label-class="labelClasses" v-bind="$attrs">
+  <w-toggle-item v-if="radio || checkbox" :class="ccClickable.clickable" :type="type" :label-class="labelClasses" v-bind="$attrs">
     <slot />
   </w-toggle-item>
   <component v-else :is="href ? 'a' : 'button'" :class="labelClasses" :href="href" :type="href ? undefined : ($attrs.type || 'button')">
-    <span :class="clickableClasses" aria-hidden="true" />
+    <span :class="ccClickable.clickable" aria-hidden="true" />
     <slot />
   </component>
 </template>


### PR DESCRIPTION
Clean up w-clickable as `focusable` related stuff is now moved to component classes https://github.com/warp-ds/component-classes/pull/70