### PR TITLE
fix: provide props to textarea

### DIFF
--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -8,6 +8,8 @@
             [ccInput.invalid]: hasValidationErrors,
           }
         ]"
+        :disabled="disabled"
+        :readOnly="readOnly"
         v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" 
       />
     </div>


### PR DESCRIPTION
It should not be possible to tab through the disabled textarea.

Reproducable in the [tech docs](http://localhost:5174/tech-docs/components/textarea/) and locally