### PR TITLE
fix(buttons): bump component-classes to 1.0.0-alpha.116

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.115",
+    "@warp-ds/component-classes": "^1.0.0-alpha.116",
     "@warp-ds/uno": "1.0.0-alpha.49",
     "@floating-ui/dom": "^1.4.2",
     "create-v-model": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^1.4.2
     version: 1.4.2
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.115
-    version: 1.0.0-alpha.115
+    specifier: ^1.0.0-alpha.116
+    version: 1.0.0-alpha.116
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -1547,8 +1547,8 @@ packages:
       vue-component-type-helpers: 1.6.5
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.115:
-    resolution: {integrity: sha512-+Gvds1oLj2Jj5WW5hwFCPts2K0L3/yQCCMg6io49QnZ0qDwd6whof3TkDg7emhqF+xEVh87r67bqLewZbOsnyg==}
+  /@warp-ds/component-classes@1.0.0-alpha.116:
+    resolution: {integrity: sha512-7bAQOPtynoGtgcZ+TSX6OE+chK2s0tW/fnE1dOScjDMvd7O+6EFbBi3eTKSnmozEKL/d9c7gGL/9/OnGxlF9lg==}
     dev: false
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
Fixes line-height issues on small buttons

Before:
<img width="375" alt="Screenshot 2023-07-10 at 11 00 39" src="https://github.com/warp-ds/component-classes/assets/41303231/3072ed0e-9c31-481b-acc9-a156d660d813">

After:
<img width="373" alt="Screenshot 2023-07-10 at 11 01 26" src="https://github.com/warp-ds/component-classes/assets/41303231/873f757a-41f6-4186-b975-9100ff8c5aa1">