### PR TITLE
fix: trigger release of 1.0.0-alpha.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.0.0-alpha.44](https://github.com/warp-ds/vue/compare/v1.0.0-alpha.43...v1.0.0-alpha.44) (2023-07-14)
-
-
-### Bug Fixes
-
-* use css package instead of component-classes ([#52](https://github.com/warp-ds/vue/issues/52)) ([625d061](https://github.com/warp-ds/vue/commit/625d061f61abd823fae28400a9d1b3e81f0e9f5c))
-
 # [1.0.0-alpha.43](https://github.com/warp-ds/vue/compare/v1.0.0-alpha.42...v1.0.0-alpha.43) (2023-07-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/vue",
   "repository": "git@github.com:warp-ds/vue.git",
-  "version": "1.0.0-alpha.44",
+  "version": "1.0.0-alpha.43",
   "description": "Warp components for Vue 3",
   "type": "module",
   "exports": {


### PR DESCRIPTION
The release job failed in https://github.com/warp-ds/vue/actions/runs/5551990370 so we need to trigger it again by:
a) removing the 1.0.0-alpha.44 tag from https://github.com/warp-ds/vue/tags
b) reverting the last semantic-release-bot commit: 80778ecf5e34150cd43af4a0ab8a5cedd48ba0f0.
c) setting `fix:` prefix on the PR title to tell semantic-release we want our changes released.
