### PR TITLE
fix: add test case for negative button as it is not just modifier any more but it is own button type

### DIFF
--- a/test/wButton.test.js
+++ b/test/wButton.test.js
@@ -23,6 +23,11 @@ describe('button', () => {
     assert.equal(wrapper.text(), 'Hello Warp')
     assert.include(wrapper.classes().join(' '), ccButton.primary)
   })
+  test('negative', () => {
+    const wrapper = mount(wButton, { props: { negative: true, label } })
+    assert.equal(wrapper.text(), 'Hello Warp')
+    assert.include(wrapper.classes().join(' '), ccButton.negative)
+  })
   test('href', () => {
     const href = 'https://finn.no'
     const wrapper = mount(wButton, { props: { label, href } })


### PR DESCRIPTION
Add a test case for a negative button so we can visualize in the changelog that it is no longer a modifier but a button type. This is to align what we have in other frameworks. Fix for that was done [here](https://github.com/warp-ds/vue/commit/1c9fa6c4326d2527f1db58f6d94c19ab3e215031) but the commit message did not reflect the change unfortunately.

Tech docs will be updated accordingly