### PR TITLE
fix(buttons): set secondary variant styles by default

### DIFF
--- a/components/button/w-button.vue
+++ b/components/button/w-button.vue
@@ -26,7 +26,7 @@ const ariaValueText = i18n._({
   comment: 'Screenreader message for buttons that are loading'
 });
 
-const buttonTypes = [    
+const buttonVariants = [
   'primary',
   'secondary',
   'negative',
@@ -50,17 +50,17 @@ const props = defineProps({
   label: String,
 })
 
-const buttonType = buttonTypes.find(b => !!props[b]);
+const defaultVariant = props.secondary || !buttonVariants.find(b => !!props[b]);
 
 const buttonClass = computed(() => ({
-  [ccButton.secondary]: (props.secondary || !buttonType) && !props.small && !props.quiet && !props.loading,
-  [ccButton.secondarySmall]: props.secondary && props.small && !props.quiet && !props.loading,
-  [ccButton.secondarySmallLoading]: props.secondary && props.small && !props.quiet && props.loading,
-  [ccButton.secondarySmallQuiet]: props.secondary && props.small && props.quiet && !props.loading,
-  [ccButton.secondarySmallQuietLoading]: props.secondary && props.small && props.quiet && props.loading,
-  [ccButton.secondaryQuiet]: props.secondary && !props.small && props.quiet && !props.loading,
-  [ccButton.secondaryQuietLoading]: props.secondary && !props.small && props.quiet && props.loading,
-  [ccButton.secondaryLoading]: props.secondary && !props.small && !props.quiet && props.loading,
+  [ccButton.secondary]: defaultVariant && !props.small && !props.quiet && !props.loading,
+  [ccButton.secondarySmall]: defaultVariant && props.small && !props.quiet && !props.loading,
+  [ccButton.secondarySmallLoading]: defaultVariant && props.small && !props.quiet && props.loading,
+  [ccButton.secondarySmallQuiet]: defaultVariant && props.small && props.quiet && !props.loading,
+  [ccButton.secondarySmallQuietLoading]: defaultVariant && props.small && props.quiet && props.loading,
+  [ccButton.secondaryQuiet]: defaultVariant && !props.small && props.quiet && !props.loading,
+  [ccButton.secondaryQuietLoading]: defaultVariant && !props.small && props.quiet && props.loading,
+  [ccButton.secondaryLoading]: defaultVariant && !props.small && !props.quiet && props.loading,
   
   [ccButton.primary]: props.primary && !props.small && !props.quiet && !props.loading,
   [ccButton.primarySmall]: props.primary && props.small && !props.quiet && !props.loading,

--- a/test/wButton.test.js
+++ b/test/wButton.test.js
@@ -28,6 +28,18 @@ describe('button', () => {
     assert.equal(wrapper.text(), 'Hello Warp')
     assert.include(wrapper.classes().join(' '), ccButton.negative)
   })
+  test('no variant should default to secondary', () => {
+    const wrapper = mount(wButton)
+    assert.include(wrapper.classes().join(' '), ccButton.secondary)
+  })
+  test('small with no variant should default to secondary small', () => {
+    const wrapper = mount(wButton, { props: { small: true } })
+    assert.include(wrapper.classes().join(' '), ccButton.secondarySmall)
+  })
+  test('small & quiet with no variant should default to secondary small quiet', () => {
+    const wrapper = mount(wButton, { props: { small: true, quiet: true } })
+    assert.include(wrapper.classes().join(' '), ccButton.secondarySmallQuiet)
+  })
   test('href', () => {
     const href = 'https://finn.no'
     const wrapper = mount(wButton, { props: { label, href } })


### PR DESCRIPTION
Fixes issues where buttons receiving only modifier props like `small`, `loading`, `quiet` (without any variant prop) weren't applying any classes. The default button variant in such case should be "secondary".

Also renamed `buttonTypes` to `buttonVariants` to align with [Warp Elements API](https://github.com/warp-ds/elements/blob/next/packages/button/index.js#L39) and to avoid confusion with another prop that is called `type`.

Before:
![bug-button-default-style](https://github.com/warp-ds/vue/assets/41303231/4b71a3f5-f193-4e88-a543-aa8c2f6fa27b)


After:
![button-default-style](https://github.com/warp-ds/vue/assets/41303231/2e0e6e56-b18a-401c-be2d-765558e26878)

