### PR TITLE
fix(changelog): remove changes related to unreleased commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,3 @@
-## [1.0.1-next.1](https://github.com/warp-ds/vue/compare/v1.0.0...v1.0.1-next.1) (2023-09-18)
-
-
-### Bug Fixes
-
-* add test case for negative button as it is not just modifier anymore but it is own button type ([#63](https://github.com/warp-ds/vue/issues/63)) ([c9d4950](https://github.com/warp-ds/vue/commit/c9d4950278ee7bbddc80709b3a2161009c15aa2a))
-* **buttons:** set secondary variant styles by default ([#67](https://github.com/warp-ds/vue/issues/67)) ([cde4077](https://github.com/warp-ds/vue/commit/cde407790650b8b694b2cd5d26ede774719a8ae3))
-* use new button classes and improve conditions ([#62](https://github.com/warp-ds/vue/issues/62)) ([1c9fa6c](https://github.com/warp-ds/vue/commit/1c9fa6c4326d2527f1db58f6d94c19ab3e215031))
-
-## [1.0.1-next.1](https://github.com/warp-ds/vue/compare/v1.0.0...v1.0.1-next.1) (2023-09-04)
-
-
-### Bug Fixes
-
-* add test case for negative button as it is not just modifier anymore but it is own button type ([#63](https://github.com/warp-ds/vue/issues/63)) ([c9d4950](https://github.com/warp-ds/vue/commit/c9d4950278ee7bbddc80709b3a2161009c15aa2a))
-* use new button classes and improve conditions ([#62](https://github.com/warp-ds/vue/issues/62)) ([1c9fa6c](https://github.com/warp-ds/vue/commit/1c9fa6c4326d2527f1db58f6d94c19ab3e215031))
-
 ## [1.0.1-next.1](https://github.com/warp-ds/vue/compare/v1.0.0...v1.0.1-next.1) (2023-09-01)
 
 


### PR DESCRIPTION
There was a bug with `v1.0.1-next.1` tag pointing at a wrong commit hash, which resulted in the last two releases to NPM fail ([link to failed job](https://github.com/warp-ds/vue/actions/runs/6070116695/job/16465578323)). This bug was caused by an attempt to update a semantic-release-bot commit and force-pushing it to `next` branch. The commit hash changed and so semantic release had no reference to the commit tagged by `v1.0.1-next.1`.

The solution was to force-update the referenced commit hash in `v1.0.1-next.1` tag.

Now that the two last commits can be released by merging this PR, the related changelog messages can be removed. They will be generated by semantic release upon suffessful release of v1.0.1-next.2 🤞 