### PR TITLE
fix: make tabs accessible for using keyboard keys again

### DIFF
--- a/components/tabs/w-tab.vue
+++ b/components/tabs/w-tab.vue
@@ -48,7 +48,7 @@ const contentClasses = computed(() => ({
     :aria-selected="isActive"
     :aria-controls="isActive ? `warp-tabpanel-${name}` : undefined"
     :tabindex="isActive ? 0 : -1"
-    @keydown="onKeydown"
+    @keydown="controller.onKeydown"
   >
     <span v-if="$slots.default" :class="iconClasses">
       <slot />


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?label=web&selectedIssue=WARP-14

To reproduce: try to navigate between tabs with the help of the arrow on the keyboard here https://warp-ds.github.io/tech-docs/components/tabs/
To test this PR:
- checkout this branch
- go to the test page, should be something like http://localhost:3003/tabs but mind the PORT that can be different when you run locally.
- try to navigate between tabs with keyboard arrows

https://github.com/warp-ds/vue/assets/37986637/4fea945a-06ad-40b3-89bc-553e187a4551


