### PR TITLE
docs: add proper instructions to be able to run local env with shiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,14 @@ Install dependencies by running:
 pnpm install
 ```
 
+### Shiki
+
+Run following to prepare for visualizing the examples and corresponding code:
+
+```sh
+pnpm run cp && pnpm run cp:shikifix
+```
+
 
 ### Start dev server
 


### PR DESCRIPTION
For newcomers it is impossible to know why the local env is failing when they run `pnpm dev`. Added instructions to make it more clear what the steps should be.