### PR TITLE
fix(alert): use h3 for title in Alert to fix accessibility issues

### DIFF
--- a/components/alert/w-alert.vue
+++ b/components/alert/w-alert.vue
@@ -59,7 +59,7 @@ const iconComponent = computed(() =>
             <component :is="iconComponent" />
           </div>
           <div :class="ccAlert.textWrapper" data-test="content">
-            <p :class="ccAlert.title" v-if="title">{{ title }}</p>
+            <h3 :class="ccAlert.title" v-if="title">{{ title }}</h3>
             <slot />
           </div>
         </div>

--- a/dev/pages/Alert.vue
+++ b/dev/pages/Alert.vue
@@ -20,7 +20,8 @@ const variants = {
   },
   Positive: {
     positive: true,
-    title: `Hooray ${sentence}!`
+    title: `Hooray ${sentence}!`,
+    role: 'status'
   },
   Warning: {
     warning: true,
@@ -28,7 +29,8 @@ const variants = {
   },
   Info: {
     info: true,
-    title: `Just so you know, ${sentence}.`
+    title: `Just so you know, ${sentence}.`,
+    role: 'status'
   }
 }
 const current = reactive({ active: 'Negative' })
@@ -44,6 +46,11 @@ const variantControls = [
   <div>
     <component-title title="Alert" />
 
+    <demo-controls class="flex" x>
+      <demo-control label="Visibility" :controls="showControls" :state="showState" />
+      <demo-control label="Variants" :controls="variantControls" :state="current" />
+    </demo-controls>
+
     <token :state="[showState, current]">
       <w-alert v-model="showState.Show" v-bind="variants[current.active]">
         <p>This is the message text that can be short or a little bit long</p>
@@ -53,10 +60,5 @@ const variantControls = [
         </div>
       </w-alert>
     </token>
-
-    <demo-controls class="flex" x>
-      <demo-control label="Visibility" :controls="showControls" :state="showState" />
-      <demo-control label="Variants" :controls="variantControls" :state="current" />
-    </demo-controls>
   </div>
 </template>

--- a/test/wAlert.test.js
+++ b/test/wAlert.test.js
@@ -14,7 +14,7 @@ describe('alert', () => {
       slots: { default: defaultSlot } })
     const html = wrapper.get('div[data-test="content"]')
     const wrapperHtml = wrapper.get('div[data-test="wrapper"]')
-    const titleHtml = wrapper.get('p')
+    const titleHtml = wrapper.get('h3')
     assert.equal(titleHtml.text(), title)
     assert.include(html.html(), defaultSlot)
     assert.include(wrapper.html(), '<svg ')
@@ -25,7 +25,7 @@ describe('alert', () => {
     const AlertFixture = {
       template: `
         <w-alert v-model="model" title="Hello">
-          <h1>OMG WTF BBQ</h1>
+          <h4>OMG WTF BBQ</h4>
         </w-alert>
       `,
       components: { wAlert },


### PR DESCRIPTION
If h3 is not the right heading level, users can always pass a title element as child to the Alert component.
![Alert with correct looking title](https://github.com/warp-ds/vue/assets/41303231/f8094086-db99-418a-8eb9-76ef198ad639)
