### PR TITLE
fix: modal ay11 fixes

### DIFF
--- a/components/modal/w-modal.vue
+++ b/components/modal/w-modal.vue
@@ -131,7 +131,7 @@ const emit = defineEmits(['dismiss', 'left', 'right', 'shown', 'hidden']);
                 </slot>
               </button>
               <div :class="titleCenterClasses" key="title" v-bind="titleAttrs">
-                <p id="w-modal-title" :class="ccModal.titleText" v-if="title">{{ title }}</p>
+                <h1 id="w-modal-title" :class="ccModal.titleText" v-if="title">{{ title }}</h1>
                 <slot name="title" />
               </div>
               <button v-if="right" :aria-label="ariaClose" @click="$emit('right')" :class="titleRightClasses" key="right" v-bind="right">

--- a/dev/pages/Modal.vue
+++ b/dev/pages/Modal.vue
@@ -27,7 +27,7 @@ watch(showModal, (showing) => modalShowing.value = showing)
 
     <token>
       <w-modal title="Hello Warp!" :style="demoStyles" :left="showLeft" right @dismiss="showModal = false" v-model="showModal" @right="showModal = false">
-        <div class="space-x-8">
+        <div class="space-x-8 pt-4">
           <w-button utility @click="changeHeight" small class="mb-32">Modify height</w-button>
           <w-button utility @click="showLeft = !showLeft" small class="mb-32">Toggle the back-button</w-button>
         </div>


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?label=web&selectedIssue=WARP-321

Part that is fixed here: **The title inside the dialog should be a heading. (make h1 as default instead of p)**