### PR TITLE
fix(breadcrumbs): removed double aria label and removed aria-hidden f…

### DIFF
--- a/components/breadcrumbs/w-breadcrumbs.vue
+++ b/components/breadcrumbs/w-breadcrumbs.vue
@@ -1,6 +1,6 @@
 <template>
-  <nav :aria-label="ariaLabel">
-    <h2 :class="ccBreadcrumbs.a11y">{{ ariaLabel }}</h2>
+  <nav aria-labelledby="breadCrumbLabel">
+    <h2 id="breadCrumbLabel" :class="ccBreadcrumbs.a11y">{{ ariaLabel }}</h2>
     <div :class="ccBreadcrumbs.wrapper">
       <breadcrumbify>
         <slot />
@@ -44,6 +44,6 @@ const Breadcrumbify = (_, context) => {
 </script>
 
 <script>
-  export const wBreadcrumbSeparator = h('span', { ariaHidden: true, class: ccBreadcrumbs.separator }, '/')
+  export const wBreadcrumbSeparator = h('span', { class: ccBreadcrumbs.separator }, '/')
   export default { name: 'wBreadcrumbs' }
 </script>

--- a/test/wBreadcrumbs.test.js
+++ b/test/wBreadcrumbs.test.js
@@ -1,22 +1,27 @@
-import { describe, test, assert } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { wBreadcrumbs } from '#components'
+import { describe, test, assert } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { wBreadcrumbs } from '#components';
 
 describe('breadcrumbs', () => {
-  assert.ok(wBreadcrumbs.name)
+  assert.ok(wBreadcrumbs.name);
 
   test('normal', () => {
     const defaultSlot = [
       `<a href="#/foo">Foo</a>`,
       `<a href="#/bar">Bar</a>`,
-      `<span aria-current="page">Baz</span>`
-    ]
-    const wrapper = mount(wBreadcrumbs, { slots: { default: defaultSlot } })
-    const html = wrapper.get('nav')
-    assert.include(wrapper.text(), 'Foo/Bar/Baz')
-    assert.include(wrapper.html(), 'class="select-none i-text-$color-breadcrumbs-icon"')
-    assert.ok(html.attributes()['aria-label'])
-  })
+      `<span aria-current="page">Baz</span>`,
+    ];
+    const wrapper = mount(wBreadcrumbs, {
+      slots: { default: defaultSlot },
+    });
+    const html = wrapper.get('nav');
+    assert.include(wrapper.text(), 'Foo/Bar/Baz');
+    assert.include(
+      wrapper.html(),
+      'class="select-none i-text-$color-breadcrumbs-icon"'
+    );
+    assert.ok(html.attributes()['aria-labelledby']);
+  });
   test('v-for', () => {
     const BreadcrumbFixture = {
       template: `
@@ -28,11 +33,11 @@ describe('breadcrumbs', () => {
       setup: () => ({
         crumbs: [
           { title: 'Foo', url: '/hello' },
-          { title: 'Bar', url: '/warp' }
-        ]
-      })
-    }
-    const wrapper = mount(BreadcrumbFixture)
-    assert.include(wrapper.text(), 'Foo/Bar')
-  })
-})
+          { title: 'Bar', url: '/warp' },
+        ],
+      }),
+    };
+    const wrapper = mount(BreadcrumbFixture);
+    assert.include(wrapper.text(), 'Foo/Bar');
+  });
+});


### PR DESCRIPTION
- Removed double Aria label
- Removed aria-hidden from the seperators



This component assumes there is only one Breadcrumb on any single page. We should prob. not make assumptions like this anymore in any of or components and perhaps look into as separate tasks: 
- Random key gen all(?) ID's  (as in moving/modernizing this <code>@warp-ds/elements/packages/utils/index.js</code> <code>generateRandomId()</code> to a broader warp toolbox )
- Accept a root heading level if supplied to the component (we prob need to modernize the <code>unstyled-heading.js</code> script for this)