### PR TITLE
fix: a11y fixes for steps

### DIFF
--- a/components/steps/locales/en/messages.mjs
+++ b/components/steps/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"steps.aria.emptyCircle\":\"Empty circle\",\"steps.aria.active\":\"Step indicator active circle\",\"steps.aria.completed\":\"Step indicator completed circle\"}");

--- a/components/steps/locales/en/messages.po
+++ b/components/steps/locales/en/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-10-25 15:01+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+
+#. Empty circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:32
+msgid "steps.aria.emptyCircle"
+msgstr "Empty circle"
+
+#. Active circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:25
+msgid "steps.aria.active"
+msgstr "Step indicator active circle"
+
+#. Completed circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:18
+msgid "steps.aria.completed"
+msgstr "Step indicator completed circle"

--- a/components/steps/locales/fi/messages.mjs
+++ b/components/steps/locales/fi/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"steps.aria.emptyCircle\":\"Empty circle\",\"steps.aria.active\":\"Step indicator active circle\",\"steps.aria.completed\":\"Step indicator completed circle\"}");

--- a/components/steps/locales/fi/messages.po
+++ b/components/steps/locales/fi/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-10-25 15:01+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fi\n"
+
+#. Empty circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:32
+msgid "steps.aria.emptyCircle"
+msgstr ""
+
+#. Active circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:25
+msgid "steps.aria.active"
+msgstr ""
+
+#. Completed circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:18
+msgid "steps.aria.completed"
+msgstr ""

--- a/components/steps/locales/nb/messages.mjs
+++ b/components/steps/locales/nb/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"steps.aria.emptyCircle\":\"Empty circle\",\"steps.aria.active\":\"Step indicator active circle\",\"steps.aria.completed\":\"Step indicator completed circle\"}");

--- a/components/steps/locales/nb/messages.po
+++ b/components/steps/locales/nb/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-10-25 15:01+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb\n"
+
+#. Empty circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:32
+msgid "steps.aria.emptyCircle"
+msgstr ""
+
+#. Active circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:25
+msgid "steps.aria.active"
+msgstr ""
+
+#. Completed circle
+#. js-lingui-explicit-id
+#: components/steps/w-step.vue:18
+msgid "steps.aria.completed"
+msgstr ""

--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -1,7 +1,15 @@
 <script setup>
 import { computed, inject } from 'vue';
+import { i18n } from '@lingui/core';
+import { activateI18n } from '../util/i18n';
 import { step as ccStep } from '@warp-ds/css/component-classes';
 import { IconCheck16 } from "@warp-ds/icons/vue";
+import { messages as enMessages} from './locales/en/messages.mjs';
+import { messages as nbMessages} from './locales/nb/messages.mjs';
+import { messages as fiMessages} from './locales/fi/messages.mjs';
+
+
+activateI18n(enMessages, nbMessages, fiMessages);
 
 const vertical = inject('steps-vertical', true);
 const left = inject('steps-left', true);
@@ -10,6 +18,35 @@ const props = defineProps({
   active: Boolean,
   complete: Boolean,
 });
+
+const availableAriaLabels = {
+  complete: i18n._(
+    /*i18n*/ {
+      id: "steps.aria.completed",
+      message: "Step indicator completed circle",
+      comment: "Completed circle",
+    }
+  ),
+  active: i18n._(
+    /*i18n*/ {
+      id: "steps.aria.active",
+      message: "Step indicator active circle",
+      comment: "Active circle",
+    }
+  ),
+  default: i18n._(
+    /*i18n*/ {
+      id: "steps.aria.emptyCircle",
+      message: "Empty circle",
+      comment: "Empty circle",
+    }
+  )
+}
+
+const getAriaLabel = (props) => {
+  const ariaLabel = Object.keys(availableAriaLabels).find(a => props[a]);
+  return ariaLabel ? availableAriaLabels[ariaLabel] : availableAriaLabels.default;
+}
 
 const stepClasses = computed(() => [
   ccStep.step,
@@ -66,16 +103,16 @@ const contentClasses = computed(() => [
 </script>
 
 <template>
-  <div :class="stepClasses">
+  <li :class="stepClasses">
     <div v-if="!vertical" :class="horizontalClasses" />
-    <div :aria-current="active ? 'step' : undefined" :class="stepDotClasses">
+    <div role="img" :aria-label="getAriaLabel(props)" :aria-current="active ? 'step' : undefined" :class="stepDotClasses">
       <icon-check-16 v-if="complete" />
     </div>
     <div :class="stepLineClasses" />
     <div :class="contentClasses">
       <slot />
     </div>
-  </div>
+  </li>
 </template>
 
 <script>

--- a/components/steps/w-steps.vue
+++ b/components/steps/w-steps.vue
@@ -26,9 +26,9 @@ watchEffect(() => {
 </script>
 
 <template>
-  <div :class="stepsClasses">
+  <ul :class="stepsClasses">
     <slot />
-  </div>
+  </ul>
 </template>
 
 <script>

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -37,4 +37,9 @@ files:
       "dest": "vue/components/attention/messages.po",
       "translation": "/components/attention/locales/%two_letters_code%/messages.po",
     },
+    {
+      "source": "/components/steps/locales/en/messages.po",
+      "dest": "vue/components/steps/messages.po",
+      "translation": "/components/steps/locales/%two_letters_code%/messages.po",
+    },
   ]

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -31,6 +31,10 @@ const config: LinguiConfig = {
       path: '<rootDir>/components/attention/locales/{locale}/messages',
       include: ['<rootDir>/components/attention/**/*.{js,vue}'],
     },
+    {
+      path: '<rootDir>/components/steps/locales/{locale}/messages',
+      include: ['<rootDir>/components/steps/**/*.{js,vue}'],
+    },
   ],
   sourceLocale: 'en',
   compileNamespace: 'es',


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?label=web&selectedIssue=WARP-329

- [x]  Added role=img and aria-label on the divs that renders the circles (instead of alt text)
- [x]  added list markup to communicate the total number of steps to the screen reader

<img width="820" alt="image" src="https://github.com/warp-ds/vue/assets/37986637/973479e1-a488-4c7a-85a7-c11e4795150d">

