### PR TITLE
ci(crowdin-sync): don't trigger on push to main & specify files to track

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -2,7 +2,11 @@ name: Crowdin Synchronisation
 
 on:
   push:
-    branches: [next, main]
+    branches:
+      - next
+    paths:
+      - "**.po"
+      - "crowdin.yml"
 
 jobs:
   synchronize-with-crowdin:


### PR DESCRIPTION
Trigger only on push to `next` branch and if `crowdin.yml` or `.po` files change.