### PR TITLE
docs(textfield): add aria-labels to affix buttons with icons

### DIFF
--- a/dev/pages/TextField.vue
+++ b/dev/pages/TextField.vue
@@ -20,7 +20,7 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
 
     <token :state="inputModel">
       <w-textfield v-model="inputModel" class="mb-16" #suffix="{ inputElement }" label="A required input with a clear button" hint="A hint" required>
-        <w-affix suffix clear @click="handleClear(inputElement)" />
+        <w-affix suffix clear aria-label="Clear text" @click="handleClear(inputElement)" />
       </w-textfield>
     </token>
 
@@ -32,14 +32,14 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
 
     <token :state="inputModel">
       <w-textfield placeholder="I am placeholder"  #prefix v-model="inputModel" label="I have a search icon">
-        <w-affix search />
+        <w-affix search aria-label="Search" />
       </w-textfield>
     </token>
 
     <token :state="inputModel">
       <w-textfield v-model="inputModel" label="I have a prefix and a suffix" inputmode="numeric">
         <template #prefix><w-affix prefix label="+47" /></template>
-        <template #suffix><w-affix suffix clear /></template>
+        <template #suffix><w-affix suffix clear aria-label="Clear text"/></template>
       </w-textfield>
     </token>
 
@@ -57,7 +57,7 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
 
     <token :state="inputModel">
       <w-textfield #suffix v-model="inputModel" label="I have a search suffix">
-        <w-affix suffix search />
+        <w-affix suffix search aria-label="Search"/>
       </w-textfield>
     </token>
 


### PR DESCRIPTION
Fixes [WARP-337](https://nmp-jira.atlassian.net/browse/WARP-337)

Previously the clear and search Affix button would be announced using its icon's title, which describes the appearance of the icon. However, to satisfy the regulations, the Affix button’s aria-label should describe the purpose of the button, i.e. "Clear text", "Search". A11y team doesn't agree with this and says that we should rather describe its appearance, but Uu-tilsynet’s regulations trump those personal views.

In this PR we pass respective aria-labels to Affix components that render as buttons with icons. This means icons title will not be announced, but just the provided aria-label.