### PR TITLE
chore(deps): update @warp-ds/css to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@floating-ui/dom": "^1.5.1",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.2",
-    "@warp-ds/css": "^1.3.0",
+    "@warp-ds/css": "^1.4.1",
     "@warp-ds/icons": "1.2.0",
     "@warp-ds/uno": "^1.1.0",
     "create-v-model": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@floating-ui/dom':
     specifier: ^1.5.1
@@ -11,8 +15,8 @@ dependencies:
     specifier: ^1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: ^1.3.0
-    version: 1.3.0
+    specifier: ^1.4.1
+    version: 1.4.1
   '@warp-ds/icons':
     specifier: 1.2.0
     version: 1.2.0
@@ -98,10 +102,10 @@ devDependencies:
     version: 0.6.8
   unocss:
     specifier: ^0.56.0
-    version: 0.56.0(vite@4.4.9)
+    version: 0.56.0(postcss@8.4.30)(vite@4.4.9)
   vite:
     specifier: ^4.4.9
-    version: 4.4.9
+    version: 4.4.9(@types/node@20.4.2)
   viteik:
     specifier: ^1.0.3
     version: 1.0.3(@eik/rollup-plugin@4.0.50)
@@ -450,7 +454,7 @@ packages:
     resolution: {integrity: sha512-h9z1jyz0ueOwNfAPnwjJk3JGCMdm/3TFqGiGi3KqLgx3fhHgKOLmZa9fqGgX0E8arCgN2YavJwHiBCsIKTqEdQ==}
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       glob: 8.1.0
       is-glob: 4.0.3
       mime-types: 2.1.35
@@ -1164,7 +1168,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -1741,7 +1744,7 @@ packages:
       '@unocss/core': 0.56.0
       '@unocss/reset': 0.56.0
       '@unocss/vite': 0.56.0(vite@4.4.9)
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -1788,6 +1791,10 @@ packages:
     resolution: {integrity: sha512-KpaEMCg5XnTK7aQRgwNWoPCAFLEmPGjw+OSZWuMtkGvMr4RwDAVUAqPdGyGOavKMyWs+Is+lxXL5NHy9nhZ2oA==}
     dev: true
 
+  /@unocss/core@0.57.7:
+    resolution: {integrity: sha512-1d36M0CV3yC80J0pqOa5rH1BX6g2iZdtKmIb3oSBN4AWnMCSrrJEPBrUikyMq2TEQTrYWJIVDzv5A9hBUat3TA==}
+    dev: false
+
   /@unocss/extractor-arbitrary-variants@0.52.7:
     resolution: {integrity: sha512-nJ4iE7nIRpoOIQfD8S58yG4qJd6AhVPEfEOf7ksX1u8xLf71rrBIojwraRXvv7aPqNdZiWvXdh/znpA/QC5b9w==}
     dependencies:
@@ -1800,6 +1807,12 @@ packages:
       '@unocss/core': 0.56.0
     dev: true
 
+  /@unocss/extractor-arbitrary-variants@0.57.7:
+    resolution: {integrity: sha512-JdyhPlsgS0x4zoF8WYXDcusPcpU4ysE6Rkkit4a9+xUZEvg7vy7InH6PQ8dL8B9oY7pbxF7G6eFguUDpv9xx4Q==}
+    dependencies:
+      '@unocss/core': 0.57.7
+    dev: false
+
   /@unocss/inspector@0.56.0:
     resolution: {integrity: sha512-YGIyDe0eDzf0XhIHZRxZFV4xGKIA8jGBQ/rOF9k32Z8hyJ3jdJYf7s/ckA6s1kYxFq4qFmznylWeuh8JSUHeMg==}
     dependencies:
@@ -1808,9 +1821,11 @@ packages:
       sirv: 2.0.3
     dev: true
 
-  /@unocss/postcss@0.56.0:
+  /@unocss/postcss@0.56.0(postcss@8.4.30):
     resolution: {integrity: sha512-4wYpu8u8fjEeDvpA7m7Sq2wdIcXdoRSuu2HG/co7uqdXJJD6dQtOgI5Q0ooyPhWNx4w3zBCfaADBxfIcWsZotg==}
     engines: {node: '>=14'}
+    peerDependencies:
+      postcss: ^8.4.21
     dependencies:
       '@unocss/config': 0.56.0
       '@unocss/core': 0.56.0
@@ -1850,6 +1865,14 @@ packages:
       '@unocss/extractor-arbitrary-variants': 0.56.0
       '@unocss/rule-utils': 0.56.0
     dev: true
+
+  /@unocss/preset-mini@0.57.7:
+    resolution: {integrity: sha512-YPmmh+ZIg4J7/nPMfvzD1tOfUFD+8KEFXX9ISRteooflYeosn2YytGW66d/sq97AZos9N630FJ//DvPD2wfGwA==}
+    dependencies:
+      '@unocss/core': 0.57.7
+      '@unocss/extractor-arbitrary-variants': 0.57.7
+      '@unocss/rule-utils': 0.57.7
+    dev: false
 
   /@unocss/preset-tagify@0.56.0:
     resolution: {integrity: sha512-8FBHa+yPEFQ26BcqgBUrlLX7ThoMPRbH2AjQCk0RpgVhhy6OBweOFXmE0FhcOpNnM6DJadA6vlp3bTXZ0epqVA==}
@@ -1898,6 +1921,14 @@ packages:
     dependencies:
       '@unocss/core': 0.56.0
     dev: true
+
+  /@unocss/rule-utils@0.57.7:
+    resolution: {integrity: sha512-gLqbKTIetvRynLkhonu1znr+bmWnw+Cl3dFVNgZPGjiqGHd78PGS0gXQKvzuyN0iO2ADub1A7GlCWs826iEHjA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@unocss/core': 0.57.7
+      magic-string: 0.30.5
+    dev: false
 
   /@unocss/scope@0.56.0:
     resolution: {integrity: sha512-zGUxAhHh04cqzBgfsAFjQg4xsna+3Y9ST1G/Lcs3CNzm9GC/SSPwcNzFel+r75Wtx/2WlhjmWCnK5gOzRR3l6Q==}
@@ -1950,7 +1981,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.1
       magic-string: 0.30.3
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -1962,7 +1993,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
       vue: 3.3.4
     dev: true
 
@@ -2111,11 +2142,11 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.3.0:
-    resolution: {integrity: sha512-RFq9rqsRz581RB3/VfeDIebGDGbjKDbARqTSPP1tOBjUo/+mBJ80Z1RP7DV0Q3bUi+5tAz8TuPBCZcoQqToSxw==}
+  /@warp-ds/css@1.4.1:
+    resolution: {integrity: sha512-AgVOEU4f023CKTMxTnH8+BTNhGjAVux88EeIR/ikch5FM2nArCTpp7af8/qGZOhc7QDegJvHlt6DcCR7rqyIQg==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
-      '@warp-ds/uno': 1.1.0
+      '@warp-ds/uno': 1.2.0
     dev: false
 
   /@warp-ds/icons@1.2.0:
@@ -2136,6 +2167,14 @@ packages:
     dependencies:
       '@unocss/core': 0.55.3
       '@unocss/preset-mini': 0.52.7
+    dev: false
+
+  /@warp-ds/uno@1.2.0:
+    resolution: {integrity: sha512-P5zq8/Bzg33HXR0UxupqJROZK3/QFJOc+bzABN3qTihPCkiqLJCWHxqf2a61Bleg1yK4mTQv+J3FRfYyeZCUow==}
+    dependencies:
+      '@unocss/core': 0.57.7
+      '@unocss/preset-mini': 0.57.7
+      '@unocss/rule-utils': 0.57.7
     dev: false
 
   /JSONStream@1.3.5:
@@ -2192,8 +2231,10 @@ packages:
       indent-string: 5.0.0
     dev: true
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -4567,6 +4608,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
+
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -6358,7 +6406,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unocss@0.56.0(vite@4.4.9):
+  /unocss@0.56.0(postcss@8.4.30)(vite@4.4.9):
     resolution: {integrity: sha512-Ge0lMi1zYL2z/NCv0OMeYMUeLsjQGNeohSc/3qumEtGhBNiGrF6sVX80BnJ99fAFsn80nxJepWbCApUmZ/2tJA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6374,7 +6422,7 @@ packages:
       '@unocss/cli': 0.56.0
       '@unocss/core': 0.56.0
       '@unocss/extractor-arbitrary-variants': 0.56.0
-      '@unocss/postcss': 0.56.0
+      '@unocss/postcss': 0.56.0(postcss@8.4.30)
       '@unocss/preset-attributify': 0.56.0
       '@unocss/preset-icons': 0.56.0
       '@unocss/preset-mini': 0.56.0
@@ -6390,8 +6438,9 @@ packages:
       '@unocss/transformer-directives': 0.56.0
       '@unocss/transformer-variant-group': 0.56.0
       '@unocss/vite': 0.56.0(vite@4.4.9)
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
     transitivePeerDependencies:
+      - postcss
       - rollup
       - supports-color
     dev: true
@@ -6501,41 +6550,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite@4.4.9:
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.29
-      rollup: 3.28.1
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.4.9(@types/node@20.4.2):
@@ -6863,7 +6877,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
@warp-ds/css v1.4.1 introduces the following fixes:

- **expandable**: fix long titles overflowing chevron (https://github.com/warp-ds/css/issues/89) ([9de1b4c](https://github.com/warp-ds/css/commit/9de1b4cc1bd28620fefb6f30e58acfd20d7c4119))
- **expandable**: Only show focus indicator in Expandable component on focus-visible (https://github.com/warp-ds/css/issues/84) ([ccf30f2](https://github.com/warp-ds/css/commit/ccf30f2f9e20a93477cc7f5cf9dc602293320fc6))
- **tabs**: left align all tabs instead of stretch ([9b88498](https://github.com/warp-ds/css/commit/9b884986a0cff63f4e5dbd6fb8c2561331989291))
- **modal**: Z-index of Modal backdrop should be 30 according to css docs (https://github.com/warp-ds/css/issues/90) ([436b9d0](https://github.com/warp-ds/css/commit/436b9d0e5970eff412740d5758517921c928bef3))
