### PR TITLE
fix(textfield): allow styling input's left padding if prefix is wider than 40px

### DIFF
--- a/components/forms/w-textfield.vue
+++ b/components/forms/w-textfield.vue
@@ -77,6 +77,7 @@ const inputClasses = computed(() => ({
   </w-field>
 </template>
 
+<!-- we style input with prefix here because we cannot use arbitrary values with commas in UnoCSS like pl-[var(--w-prefix-width, 40px)] -->
 <style scoped>
   div+input, button+input {
     padding-left:var(--w-prefix-width, 40px);

--- a/components/forms/w-textfield.vue
+++ b/components/forms/w-textfield.vue
@@ -77,6 +77,12 @@ const inputClasses = computed(() => ({
   </w-field>
 </template>
 
+<style scoped>
+  div+input, button+input {
+    padding-left:var(--w-prefix-width, 40px);
+  }
+</style>
+
 <script>
 const inputTypeValidator = (value) => ['text', 'search', 'email', 'password', 'url', 'tel', 'number'].includes(value);
 export default { name: 'wTextfield', inheritAttrs: false };

--- a/dev/pages/TextField.vue
+++ b/dev/pages/TextField.vue
@@ -38,7 +38,7 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
 
     <token :state="inputModel">
       <w-textfield placeholder="I am placeholder"  #prefix v-model="inputModel" label="I have a search icon">
-        <w-affix search aria-label="Search" />
+        <w-affix search prefix aria-label="Search" />
       </w-textfield>
     </token>
 
@@ -68,7 +68,7 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
     </token>
 
     <token :state="inputModel">
-      <w-textfield readOnly value="I'm read only" v-model="placeholderModel" label="I am read only">
+      <w-textfield #suffix readOnly value="I'm read only" v-model="placeholderModel" label="I am read only">
         <w-affix suffix label="NOK" />
       </w-textfield>
     </token>

--- a/dev/pages/TextField.vue
+++ b/dev/pages/TextField.vue
@@ -31,6 +31,12 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
     </token>
 
     <token :state="inputModel">
+      <w-textfield class="[--w-prefix-width:90px]" placeholder="I am placeholder" type="tel" #prefix v-model="inputModel" label="I have a prefix" inputmode="numeric">
+        <w-affix prefix label="Long prefix" />
+      </w-textfield>
+    </token>
+
+    <token :state="inputModel">
       <w-textfield placeholder="I am placeholder"  #prefix v-model="inputModel" label="I have a search icon">
         <w-affix search aria-label="Search" />
       </w-textfield>


### PR DESCRIPTION
Fixes [WARP-374](https://nmp-jira.atlassian.net/browse/WARP-374)

Prefix is an absolutely positioned component and the gap between that component and the `input`'s content is handled using a left padding on the `input`. It’s currently hard-coded to 40px, but with this quick fix we can let users change it by setting a CSS variable in `TextField`’s class (`<TextField class=”[--w-prefix-wdith: 100px]”>`). It’s not dynamic and users will need to calculate how much padding their input needs, but it’s the only non-breaking quick fix we managed to come up with. We should really consider rewriting these form components completely to properly approach styling of different text fields, affixes etc.

<img width="464" alt="Screenshot with long prefix" src="https://github.com/warp-ds/react/assets/41303231/cc3300d8-d4d0-4cc4-8666-8dc0688cb3a2">
<img width="452" alt="Screenshot with 2-letter prefix" src="https://github.com/warp-ds/react/assets/41303231/ff500993-0a96-48bc-9eec-5c1559c313d4">
<img width="454" alt="Screenshot with no prefix" src="https://github.com/warp-ds/react/assets/41303231/ac9c56e2-410a-4774-a959-98b4c4343168">
