### PR TITLE
fix(textfield): use inline style when updating input's left padding

### DIFF
--- a/components/forms/w-textfield.vue
+++ b/components/forms/w-textfield.vue
@@ -32,6 +32,10 @@ const inputClasses = computed(() => ({
   [ccInput.suffix]: slots.suffix,
   [ccInput.prefix]: slots.prefix,
 }));
+
+const inputWithPrefixStyle = computed(() => (
+  slots.prefix ? 'padding-left: var(--w-prefix-width, 40px);' : undefined
+))
 </script>
 
 <template>
@@ -71,18 +75,13 @@ const inputClasses = computed(() => ({
         :readOnly="readOnly"
         v-bind="{ ...aria, ...$attrs, class: '' }"
         @blur="triggerValidation"
+        :style="inputWithPrefixStyle"
         >
       <slot name="suffix" :inputElement="inputEl" />
     </div>
   </w-field>
 </template>
 
-<!-- we style input with prefix here because we cannot use arbitrary values with commas in UnoCSS like pl-[var(--w-prefix-width, 40px)] -->
-<style scoped>
-  div+input, button+input {
-    padding-left:var(--w-prefix-width, 40px);
-  }
-</style>
 
 <script>
 const inputTypeValidator = (value) => ['text', 'search', 'email', 'password', 'url', 'tel', 'number'].includes(value);


### PR DESCRIPTION
**This PR contains**
Changes introduced in https://github.com/warp-ds/vue/pull/115 actually work now.

There was an issue with scoped styles resulting in building [style.css file](https://assets.finn.no/pkg/@warp-ds/vue/1.2.1/style.css) and causing issues with unocss on build: https://github.com/warp-ds/vue/actions/runs/7020831994/job/19101472779#step:5:15.

**Checklist**
- [x] `pnpm build` works 
- [x] prefixed and non-prefixed text fields look correct