### PR TITLE
chore(deps): update @warp-ds/icons to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.2",
     "@warp-ds/css": "^1.4.2",
-    "@warp-ds/icons": "1.2.0",
+    "@warp-ds/icons": "1.3.0",
     "@warp-ds/uno": "^1.1.0",
     "create-v-model": "^2.2.0",
     "dom-focus-lock": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@floating-ui/dom':
     specifier: ^1.5.1
@@ -14,8 +18,8 @@ dependencies:
     specifier: ^1.4.2
     version: 1.4.2
   '@warp-ds/icons':
-    specifier: 1.2.0
-    version: 1.2.0
+    specifier: 1.3.0
+    version: 1.3.0
   '@warp-ds/uno':
     specifier: ^1.1.0
     version: 1.1.0
@@ -98,10 +102,10 @@ devDependencies:
     version: 0.6.8
   unocss:
     specifier: ^0.56.0
-    version: 0.56.0(vite@4.4.9)
+    version: 0.56.0(postcss@8.4.30)(vite@4.4.9)
   vite:
     specifier: ^4.4.9
-    version: 4.4.9
+    version: 4.4.9(@types/node@20.4.2)
   viteik:
     specifier: ^1.0.3
     version: 1.0.3(@eik/rollup-plugin@4.0.50)
@@ -450,7 +454,7 @@ packages:
     resolution: {integrity: sha512-h9z1jyz0ueOwNfAPnwjJk3JGCMdm/3TFqGiGi3KqLgx3fhHgKOLmZa9fqGgX0E8arCgN2YavJwHiBCsIKTqEdQ==}
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       glob: 8.1.0
       is-glob: 4.0.3
       mime-types: 2.1.35
@@ -1740,7 +1744,7 @@ packages:
       '@unocss/core': 0.56.0
       '@unocss/reset': 0.56.0
       '@unocss/vite': 0.56.0(vite@4.4.9)
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -1817,9 +1821,11 @@ packages:
       sirv: 2.0.3
     dev: true
 
-  /@unocss/postcss@0.56.0:
+  /@unocss/postcss@0.56.0(postcss@8.4.30):
     resolution: {integrity: sha512-4wYpu8u8fjEeDvpA7m7Sq2wdIcXdoRSuu2HG/co7uqdXJJD6dQtOgI5Q0ooyPhWNx4w3zBCfaADBxfIcWsZotg==}
     engines: {node: '>=14'}
+    peerDependencies:
+      postcss: ^8.4.21
     dependencies:
       '@unocss/config': 0.56.0
       '@unocss/core': 0.56.0
@@ -1975,7 +1981,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.1
       magic-string: 0.30.3
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -1987,7 +1993,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
       vue: 3.3.4
     dev: true
 
@@ -2143,8 +2149,8 @@ packages:
       '@warp-ds/uno': 1.2.0
     dev: false
 
-  /@warp-ds/icons@1.2.0:
-    resolution: {integrity: sha512-K8N9e08q3BEK6MwkH9AgTaHHuWy6tadsSEYa2kkfRKlKF6McHG5D/lTo/qDig6lz5TKBnBK2Qp+UnB+f16LsvQ==}
+  /@warp-ds/icons@1.3.0:
+    resolution: {integrity: sha512-YlP8p3ONQmpx8114xhySN+Rx+6hkWETXztvl3sw6MdGsXgXhNhO9pKs8x2MIx3K+R15vBfV8dt8fdqGPmFgL6w==}
     dependencies:
       '@lingui/core': 4.5.0
     dev: false
@@ -2225,8 +2231,10 @@ packages:
       indent-string: 5.0.0
     dev: true
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -6398,7 +6406,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unocss@0.56.0(vite@4.4.9):
+  /unocss@0.56.0(postcss@8.4.30)(vite@4.4.9):
     resolution: {integrity: sha512-Ge0lMi1zYL2z/NCv0OMeYMUeLsjQGNeohSc/3qumEtGhBNiGrF6sVX80BnJ99fAFsn80nxJepWbCApUmZ/2tJA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6414,7 +6422,7 @@ packages:
       '@unocss/cli': 0.56.0
       '@unocss/core': 0.56.0
       '@unocss/extractor-arbitrary-variants': 0.56.0
-      '@unocss/postcss': 0.56.0
+      '@unocss/postcss': 0.56.0(postcss@8.4.30)
       '@unocss/preset-attributify': 0.56.0
       '@unocss/preset-icons': 0.56.0
       '@unocss/preset-mini': 0.56.0
@@ -6430,8 +6438,9 @@ packages:
       '@unocss/transformer-directives': 0.56.0
       '@unocss/transformer-variant-group': 0.56.0
       '@unocss/vite': 0.56.0(vite@4.4.9)
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.4.2)
     transitivePeerDependencies:
+      - postcss
       - rollup
       - supports-color
     dev: true
@@ -6541,41 +6550,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite@4.4.9:
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.29
-      rollup: 3.28.1
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.4.9(@types/node@20.4.2):
@@ -6903,7 +6877,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
The new version doesn't affect Vue components but at least we align the @warp-ds/icons version across our component packages.