### PR TITLE
fix(card): set default background on unselected non-flat card

### DIFF
--- a/components/card/w-card.vue
+++ b/components/card/w-card.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 const outerClasses = computed(() => ({
   [ccCard.card]: true,
   [ccCard.cardShadow]: !props.flat,
-  [ccCard.cardSelected]: props.selected,
+  [props.selected ? ccCard.cardSelected : ccCard.cardUnselected]: !props.flat,
   [ccCard.cardFlat]: props.flat,
   [props.selected ? ccCard.cardFlatSelected : ccCard.cardFlatUnselected]: props.flat
 }))

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@floating-ui/dom": "^1.5.1",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.2",
-    "@warp-ds/css": "^1.4.2",
+    "@warp-ds/css": "^1.6.1",
     "@warp-ds/icons": "1.3.0",
     "@warp-ds/uno": "^1.1.0",
     "create-v-model": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: ^1.4.2
-    version: 1.4.2
+    specifier: ^1.6.1
+    version: 1.6.1
   '@warp-ds/icons':
     specifier: 1.3.0
     version: 1.3.0
@@ -2142,8 +2142,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.4.2:
-    resolution: {integrity: sha512-PuwfbtzPQs6BtBOIFJR4AmBZmoqArPvAsv5POiwPUO6cyk60K1uo0P1pZqE3CKwXR0WBoK8WnQqRh+G2IIyU5g==}
+  /@warp-ds/css@1.6.1:
+    resolution: {integrity: sha512-7Ou2eddxEzrM3KSAmEX24KOxxMGBwNbVvoOA/haM13B8UJ2wy+GDjPSx6ID58CZWFHi3DOyt9Dch0CdpnvUbjw==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
       '@warp-ds/uno': 1.2.0


### PR DESCRIPTION
Fixes [WARP-430](https://nmp-jira.atlassian.net/browse/WARP-430)

Background color of a on-flat Card will no longer be inherited from the parent container.

Before:
<img width="475" alt="Screenshot 2023-12-19 at 13 38 04" src="https://github.com/warp-ds/css/assets/41303231/476e20a3-84da-4d9b-81b1-5bf964a0ce26">

After:
<img width="529" alt="Screenshot 2023-12-19 at 15 07 38" src="https://github.com/warp-ds/css/assets/41303231/abec61bc-731e-4c70-8e73-4fc0011b2468">
