### PR TITLE
fix: adjust style for modal-title

### DIFF
--- a/components/modal/w-modal.vue
+++ b/components/modal/w-modal.vue
@@ -44,7 +44,7 @@ const emit = defineEmits(['dismiss', 'left', 'right', 'shown', 'hidden']);
     if (e.key === 'Escape') emitDismiss()
   }
   const titleLeftClasses = computed(() => ([transitions, titleShouldTransition.value ? 'duration-300' : 'duration-1', ccModal.titleButton, ccModal.titleButtonLeft]));
-  const titleCenterClasses = computed(() => ([transitions, titleShouldTransition.value ? 'duration-300' : 'duration-0', props.left ? ccModal.transitionTitleCenter : ccModal.transitionTitleColSpan]));
+  const titleCenterClasses = computed(() => ([transitions, titleShouldTransition.value ? 'duration-300' : 'duration-0', props.left ? [ccModal.transitionTitleMaxWidth, ccModal.transitionTitleCenter, ccModal.transitionTitleColSpan] : [ccModal.transitionTitleMaxWidth, ccModal.transitionTitleColSpan]]));
   const titleRightClasses = computed(() => ([transitions, titleShouldTransition.value ? 'duration-300' : 'duration-0', ccModal.titleButton, ccModal.titleButtonRight]));
 
   // when the content area reflows the title area transitions because of v-move in the transition-group

--- a/dev/pages/Modal.vue
+++ b/dev/pages/Modal.vue
@@ -26,7 +26,7 @@ watch(showModal, (showing) => modalShowing.value = showing)
     <component-title title="Modal" />
 
     <token>
-      <w-modal title="Hello Warp!" :style="demoStyles" :left="showLeft" right @dismiss="showModal = false" v-model="showModal" @right="showModal = false">
+      <w-modal title="Hello Warp!" :style="demoStyles" :left="showLeft" right @dismiss="showModal = false" v-model="showModal" @right="showModal = false" headerClasses='h-full sm:h-full'>
         <div class="space-x-8 pt-4">
           <w-button utility @click="changeHeight" small class="mb-32">Modify height</w-button>
           <w-button utility @click="showLeft = !showLeft" small class="mb-32">Toggle the back-button</w-button>


### PR DESCRIPTION
**Note:** Once [this PR](https://github.com/warp-ds/css/pull/116) has been merged and we have published a new version of @warp-ds/css, we need to update the version of @warp-ds/css in the package.json before this PR can be merged.

These changes are part of fixes for this JIRA ticket: [WARP-429](https://nmp-jira.atlassian.net/browse/WARP-429)

- Added `headerClasses` to Modal-example, changing the height of the modal title to `h-full sm:h-full`.
- Adjusted styling for the modal title after changes made in [this PR](https://github.com/warp-ds/css/pull/116)

**To test:** Link this branch with branch from the css-repo: `fix/refactor-modal-style`
