### PR TITLE
fix: replace letter x with icon close

### DIFF
--- a/components/pill/w-pill.vue
+++ b/components/pill/w-pill.vue
@@ -51,7 +51,7 @@ const removeFilterSrText = i18n._({
     </button>
     <button v-if="p.canClose" type="button" :class="closeClasses" @click="$emit('close')">
       <span v-if="!p.suggestion" :class="ccPill.a11y">{{ p.closeSRLabel || removeFilterSrText }}</span>
-      <icon-close-16 class='w-12 h-12'/>
+      <icon-close-16 />
     </button>
   </div>
 </template>

--- a/components/pill/w-pill.vue
+++ b/components/pill/w-pill.vue
@@ -2,6 +2,7 @@
 import { i18n } from '@lingui/core';
 import { computed } from 'vue';
 import { pill as ccPill } from '@warp-ds/css/component-classes';
+import IconClose16 from "@warp-ds/icons/vue/close-16";
 import { activateI18n } from '../util/i18n';
 import { messages as enMessages} from './locales/en/messages.mjs';
 import { messages as nbMessages} from './locales/nb/messages.mjs';
@@ -50,7 +51,7 @@ const removeFilterSrText = i18n._({
     </button>
     <button v-if="p.canClose" type="button" :class="closeClasses" @click="$emit('close')">
       <span v-if="!p.suggestion" :class="ccPill.a11y">{{ p.closeSRLabel || removeFilterSrText }}</span>
-      <span>x</span>
+      <icon-close-16 />
     </button>
   </div>
 </template>

--- a/components/pill/w-pill.vue
+++ b/components/pill/w-pill.vue
@@ -51,7 +51,7 @@ const removeFilterSrText = i18n._({
     </button>
     <button v-if="p.canClose" type="button" :class="closeClasses" @click="$emit('close')">
       <span v-if="!p.suggestion" :class="ccPill.a11y">{{ p.closeSRLabel || removeFilterSrText }}</span>
-      <icon-close-16 />
+      <icon-close-16 class='w-12 h-12'/>
     </button>
   </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@floating-ui/dom": "^1.5.1",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.2",
-    "@warp-ds/css": "^1.6.1",
+    "@warp-ds/css": "^1.7.0",
     "@warp-ds/icons": "1.3.0",
     "@warp-ds/uno": "^1.1.0",
     "create-v-model": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: ^1.6.1
-    version: 1.6.1
+    specifier: ^1.7.0
+    version: 1.7.0
   '@warp-ds/icons':
     specifier: 1.3.0
     version: 1.3.0
@@ -2142,8 +2142,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.6.1:
-    resolution: {integrity: sha512-7Ou2eddxEzrM3KSAmEX24KOxxMGBwNbVvoOA/haM13B8UJ2wy+GDjPSx6ID58CZWFHi3DOyt9Dch0CdpnvUbjw==}
+  /@warp-ds/css@1.7.0:
+    resolution: {integrity: sha512-fupSS33C7h+2OZ+58TUekhUnfPS1D/EW41ZoGFytyQrdS/uVNQQ/FXEOIHkumoV1m0FPj5s+qAPPuOw6oXu+Rw==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
       '@warp-ds/uno': 1.2.0


### PR DESCRIPTION
Fixes JIRA ticket: [WARP-409](https://nmp-jira.atlassian.net/browse/WARP-409)

- Replace the letter `X` with the `IconClose16` icon in our Pill component.

