### PR TITLE
fix: rename deleted icons after @warp-ds/icons update to 2.0.0

### DIFF
--- a/components/alert/w-alert.vue
+++ b/components/alert/w-alert.vue
@@ -3,10 +3,10 @@ import { computed } from "vue";
 import { wExpandTransition } from "#generics";
 import { createModel, modelProps } from "create-v-model";
 import { alert as ccAlert } from "@warp-ds/css/component-classes";
-import IconAlertError16 from "@warp-ds/icons/vue/alert-error-16";
-import IconAlertSuccess16 from "@warp-ds/icons/vue/alert-success-16";
-import IconAlertWarning16 from "@warp-ds/icons/vue/alert-warning-16";
-import IconAlertInfo16 from "@warp-ds/icons/vue/alert-info-16";
+import IconError16 from "@warp-ds/icons/vue/error-16";
+import IconSuccess16 from "@warp-ds/icons/vue/success-16";
+import IconWarning16 from "@warp-ds/icons/vue/warning-16";
+import IconInfo16 from "@warp-ds/icons/vue/info-16";
 
 const props = defineProps({
   title: String,
@@ -38,12 +38,12 @@ const iconClass = computed(() => [ccAlert.icon, activeIconClassNames.value]);
 
 const iconComponent = computed(() =>
   props.negative
-    ? IconAlertError16
+    ? IconError16
     : props.positive
-    ? IconAlertSuccess16
+    ? IconSuccess16
     : props.warning
-    ? IconAlertWarning16
-    : IconAlertInfo16
+    ? IconWarning16
+    : IconInfo16
 );
 </script>
 

--- a/components/modal/w-modal.vue
+++ b/components/modal/w-modal.vue
@@ -10,7 +10,7 @@ import { messages as enMessages} from './locales/en/messages.mjs';
 import { messages as nbMessages} from './locales/nb/messages.mjs';
 import { messages as fiMessages} from './locales/fi/messages.mjs';
 import IconClose16 from '@warp-ds/icons/vue/close-16';
-import IconTableSortDown16 from '@warp-ds/icons/vue/table-sort-down-16';
+import IconArrowLeft16 from '@warp-ds/icons/vue/arrow-left-16';
 
 activateI18n(enMessages, nbMessages, fiMessages);
 
@@ -128,7 +128,7 @@ const emit = defineEmits(['dismiss', 'left', 'right', 'shown', 'hidden']);
               >
               <button v-if="left" :aria-label="ariaBack" @click="$emit('left')" :class="titleLeftClasses" key="left" v-bind="left">
                 <slot name="left">
-                    <icon-table-sort-down-16 :class="[ccModal.titleButtonIcon, ccModal.titleButtonIconRotated]" />
+                    <icon-arrow-left-16 :class="ccModal.titleButtonIcon" />
                 </slot>
               </button>
               <div :class="titleCenterClasses" key="title" v-bind="titleAttrs">

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@lingui/core": "^4.7.0",
     "@warp-ds/core": "^1.0.2",
     "@warp-ds/css": "^1.7.0",
-    "@warp-ds/icons": "1.4.0",
+    "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "^1.6.0",
     "create-v-model": "^2.2.0",
     "dom-focus-lock": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^1.7.0
     version: 1.7.0
   '@warp-ds/icons':
-    specifier: 1.4.0
-    version: 1.4.0
+    specifier: 2.0.0
+    version: 2.0.0
   '@warp-ds/uno':
     specifier: ^1.6.0
     version: 1.6.0
@@ -5435,8 +5435,8 @@ packages:
       '@warp-ds/uno': 1.6.0
     dev: false
 
-  /@warp-ds/icons@1.4.0:
-    resolution: {integrity: sha512-CC4LlDUlSa65/ts4REDk8hVC3vY+IA6D6mhTFYg31WpOf8KwfzNY4QnEnXdzbL/1WUFU+fmUSejgqbwI8nnpVw==}
+  /@warp-ds/icons@2.0.0:
+    resolution: {integrity: sha512-a6Zi9CEunu5V0ScfaG42j5LoPK/U9uL5Gcv+/4D9FNQjaPuissqflUL3YpYI2PxTMIrHuyYXfUMWu8gBVGoUdg==}
     dependencies:
       '@lingui/core': 4.7.0
     dev: false


### PR DESCRIPTION
## Description
Fixes [WARP-498](https://nmp-jira.atlassian.net/browse/WARP-498)

This PR updates @warp-ds/icons dependency to 2.0.0 and replaces deprecated icons with the [suggested equivalents](https://warp-ds.github.io/tech-docs/components/icons/#deprecated-icons):

## What's changed
### Rename deprecated alert- icons in Alert component 
<img width="362" alt="Screenshot of Alert component variants with the new outlined icons" src="https://github.com/warp-ds/react/assets/41303231/688ea807-fa1c-40e2-8cdb-61fddf8b8d79">

### Use arrow-left icon as back button in Modal component:
<img width="466" alt="Screenshot of Modal component with back button using an arrow-left icon" src="https://github.com/warp-ds/react/assets/41303231/4fb318c3-cf6a-44be-9a93-7bef7f36f88a">
