### PR TITLE
fix: add missing aria attribute to w-textarea and w-select

### DIFF
--- a/components/forms/w-select.vue
+++ b/components/forms/w-select.vue
@@ -31,7 +31,7 @@ const chevronClasses = computed(() => ({
 </script>
 
 <template>
-  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, hasValidationErrors }">
+  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria, hasValidationErrors }">
     <div :class="wrapperClasses">
       <div :class="selectWrapperClasses">
         <select
@@ -43,7 +43,7 @@ const chevronClasses = computed(() => ({
           ]"
           :disabled="disabled"
           :readOnly="readOnly"
-          v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation">
+          v-bind="{ ...aria, ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation">
           <slot />
         </select>
         <div :class="chevronClasses">

--- a/components/forms/w-textarea.vue
+++ b/components/forms/w-textarea.vue
@@ -1,5 +1,5 @@
 <template>
-  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, hasValidationErrors }">
+  <w-field v-bind="{ ...$attrs, ...$props }" #default="{ triggerValidation, aria, hasValidationErrors }">
     <div :class="wrapperClass">
       <textarea         
         :class="[
@@ -10,7 +10,7 @@
         ]"
         :disabled="disabled"
         :readOnly="readOnly"
-        v-bind="{ ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" 
+        v-bind="{ ...aria, ...$attrs, class: '' }" v-model="model" :id="id" @blur="triggerValidation" 
       />
     </div>
   </w-field>


### PR DESCRIPTION
Fixes JIRA ticket: [WARP-517](https://nmp-jira.atlassian.net/browse/WARP-517)

- Add missing `aria` attribute to `w-textarea` and `w-select`