### PR TITLE
fix(w-field): ensure default error text is translated on time

### DIFF
--- a/components/forms/validation.js
+++ b/components/forms/validation.js
@@ -1,15 +1,7 @@
 import { ref, reactive, computed, watch, provide, inject, onBeforeUnmount } from 'vue'
-import { i18n } from '@lingui/core';
 
 export const defaultValid = { valid: true }
-export const defaultInvalid = {
-  valid: false,
-  hint: i18n._({
-    id:'forms.validation.mandatoryField', 
-    message: 'Mandatory field',
-    comment: 'Text visible below input field if validation fails'
-  })
-}
+export const defaultInvalid = { valid: false }
 
 export function defaultRequiredRule(v) {
   if (v == null) return defaultInvalid // check for null or undefined

--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,12 +1,12 @@
 <template>
   <component :is="as" :class="{[ccInput.wrapper]: true, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
-    <component :is="labelType" v-if="label" :class="{[ccLabel.label]: true, [ccLabel.labelInvalid]: hasErrorMessage}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional">{{ optionalHelperText }}</span></component>
-    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" :hasValidationErrors="hasValidationErrors" />
+    <component :is="labelType" v-if="label" :class="{[ccLabel.label]: true, [ccLabel.labelInvalid]: isInvalid}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional">{{ optionalHelperText }}</span></component>
+    <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" :hasValidationErrors="isInvalid" />
     <slot name="control" :form="collector" />
-    <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextInvalid]: hasErrorMessage}" v-if="hint || hasErrorMessage">
+    <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextInvalid]: isInvalid}" v-if="hint || isInvalid">
       <span :id="hintId" v-if="hint" v-html="hint" />
-      <span v-if="hint && hasErrorMessage">, </span>
-      <span :id="errorId" v-if="hasErrorMessage">{{ validationMsg }}</span>
+      <span v-if="hint && isInvalid">, </span>
+      <span :id="errorId" v-if="isInvalid">{{ errorMessage }}</span>
     </div>
   </component>
 </template>
@@ -59,25 +59,31 @@ export default {
   },
   setup(props, { slots }) {
 
-    const { triggerValidation, valid, validationMsg, hasErrorMessage, collector } = createValidation(props)
+    const { triggerValidation, validationMsg, hasErrorMessage, collector } = createValidation(props)
 
+    const isInvalid = computed(() => !!hasErrorMessage.value || props.invalid)
     const isFieldset = computed(() => props.as === 'fieldset')
     const labelType = computed(() => isFieldset.value ? 'legend' : 'label')
     const labelFor = computed(() => isFieldset.value ? undefined : props.id)
     const labelId = computed(() => (props.label || slots.label) && (props.id + ':label'))
-    const hintId = computed(() => props.id + ':hint')
-    const errorId = computed(() => valueOrUndefined(hasErrorMessage.value, props.id + ':error'))
+    const hintId = computed(() => valueOrUndefined(props.hint, props.id + ':hint'))
+    const errorId = computed(() => valueOrUndefined(isInvalid.value, props.id + ':error'))
     const aria = computed(() => ({
       'aria-labelledby': labelId.value,
-      'aria-describedby': valueOrUndefined(props.hint, hintId.value),
+      'aria-describedby': hintId.value,
       'aria-errormessage': errorId.value,
-      'aria-invalid': !valid.value || props.invalid || undefined,
+      'aria-invalid': isInvalid.value || undefined,
       'aria-required': props.required && true
     }))
     const wrapperAria = computed(() => valueOrUndefined(isFieldset.value, aria.value))
     const optionalHelperText = i18n._({ id: 'forms.field.label.optional', message: '(optional)', comment: 'Shown after label when marked as optional'});
-    const hasValidationErrors = computed(() => !!hasErrorMessage.value);
-    return { triggerValidation, validationMsg, hasErrorMessage, labelType, labelFor, labelId, hintId, errorId, aria, wrapperAria, collector, valueOrUndefined, ccInput, ccLabel, ccHelpText, hasValidationErrors, optionalHelperText }
+    const errorMessage = validationMsg.value || i18n._({
+      id:'forms.validation.mandatoryField', 
+      message: 'Mandatory field',
+      comment: 'Text visible below input field if validation fails'
+    })
+
+    return { triggerValidation, errorMessage, labelType, labelFor, labelId, hintId, errorId, aria, wrapperAria, collector, valueOrUndefined, ccInput, ccLabel, ccHelpText, isInvalid, optionalHelperText }
   }
 }
 </script>

--- a/dev/pages/TextField.vue
+++ b/dev/pages/TextField.vue
@@ -73,6 +73,12 @@ const moneyMask = { numeral: true, numeralPositiveOnly: true, numeralIntegerScal
       </w-textfield>
     </token>
 
+    <token :state="inputModel">
+      <w-textfield label="I am invalid" #suffix invalid required v-model="inputModel">
+        <w-affix suffix clear aria-label="Clear text" @click="handleClear" />
+      </w-textfield>
+    </token>
+
     <token :state="numericInputModel">
       <w-textfield placeholder="I am placeholder" v-model.number="numericInputModel" optional number type="text" inputmode="numeric" :mask="moneyMask" label="A masked (money) input" />
     </token>

--- a/dev/pages/Textarea.vue
+++ b/dev/pages/Textarea.vue
@@ -21,7 +21,7 @@ const model = ref('')
     </token>
 
     <token :state="model" >
-      <w-textarea v-model="model" required label="A required textarea" hint="A hint" />
+      <w-textarea v-model="model" invalid required label="A required textarea" hint="A hint" />
     </token>
   </div>
 </template>


### PR DESCRIPTION
## Description
Fixes [WARP-519](https://nmp-jira.atlassian.net/browse/WARP-519) and [WARP-518](https://nmp-jira.atlassian.net/browse/WARP-518)

The `i18n` call is now moved to `w-field` in order for the `validationMsg` translation to trigger in the right moment.

Additionally:
- `hasValidationErrors` is replaced with `isInvalid` to simplify the validation logic in the template
- `invalid` prop is now included in the validation checks, so when a component relies on `invalid` prop when handling validation, it also contains default validation message and respective aria attributes

![invalid](https://github.com/warp-ds/vue/assets/41303231/51d3876c-dd70-45b8-a02d-c77c6a77922e)
