### PR TITLE
fix(field): use correct colors in label and hint/error text

### DIFF
--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -3,7 +3,7 @@
     <component :is="labelType" v-if="label" :class="ccLabel.label" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional">{{ optionalHelperText }}</span></component>
     <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" :hasValidationErrors="isInvalid" />
     <slot name="control" :form="collector" />
-    <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextInvalid]: isInvalid}" v-if="hint || isInvalid">
+    <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextColor]: !isInvalid, [ccHelpText.helpTextColorInvalid]: isInvalid}" v-if="hint || isInvalid">
       <span :id="hintId" v-if="hint" v-html="hint" />
       <span v-if="hint && isInvalid">, </span>
       <span :id="errorId" v-if="isInvalid">{{ errorMessage }}</span>

--- a/components/forms/w-field.vue
+++ b/components/forms/w-field.vue
@@ -1,6 +1,6 @@
 <template>
   <component :is="as" :class="{[ccInput.wrapper]: true, [$attrs.class || '']: true}" :role="role" v-bind="wrapperAria">
-    <component :is="labelType" v-if="label" :class="{[ccLabel.label]: true, [ccLabel.labelInvalid]: isInvalid}" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional">{{ optionalHelperText }}</span></component>
+    <component :is="labelType" v-if="label" :class="ccLabel.label" :id="labelId" :for="labelFor" :role="valueOrUndefined(labelLevel, 'heading')" :aria-level="valueOrUndefined(labelLevel, labelLevel)">{{ label }}<span v-if="optional" :class="ccLabel.optional">{{ optionalHelperText }}</span></component>
     <slot :triggerValidation="triggerValidation" :labelFor="id" :labelId="labelId" :aria="aria" :hasValidationErrors="isInvalid" />
     <slot name="control" :form="collector" />
     <div :class="{[ccHelpText.helpText]: true, [ccHelpText.helpTextInvalid]: isInvalid}" v-if="hint || isInvalid">

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@floating-ui/dom": "1.6.3",
     "@lingui/core": "^4.7.0",
     "@warp-ds/core": "^1.0.2",
-    "@warp-ds/css": "1.8.4",
+    "@warp-ds/css": "1.9.1",
     "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.9.0",
     "create-v-model": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: 1.8.4
-    version: 1.8.4
+    specifier: 1.9.1
+    version: 1.9.1
   '@warp-ds/icons':
     specifier: 2.0.0
     version: 2.0.0
@@ -4626,7 +4626,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.19(typescript@5.3.3)
-      vue-component-type-helpers: 2.0.6
+      vue-component-type-helpers: 2.0.7
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5488,8 +5488,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.8.4:
-    resolution: {integrity: sha512-SGX3bORF13I20XzCg4Ab0FlUe7Yj4XUH1/klu+NeCVrIWymPhExgFTbFJrs+9RvTKh81d4/IFiyiqdHSpRG6iw==}
+  /@warp-ds/css@1.9.1:
+    resolution: {integrity: sha512-AlfEwB0ernCxA/TccSElR2sJcTP6crEJthBHBvJyqi+TpUFE8R/8oCdw2Lh4rDCG3b86dtfthi1hzp9JN0LK9w==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.9.0
@@ -5505,7 +5505,7 @@ packages:
     resolution: {integrity: sha512-D4qIUQdY0Tp23OpeR6P9T5QXpsr9crN/FusHWN+975Yk5WoWZOMAf7SVyvgFKV0uq5s70I3qlZqjT51khMwPNQ==}
     dependencies:
       glob: 10.3.10
-      yaml: 2.3.4
+      yaml: 2.4.1
     dev: false
 
   /@warp-ds/uno@1.9.0:
@@ -13065,8 +13065,8 @@ packages:
     resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.6:
-    resolution: {integrity: sha512-qdGXCtoBrwqk1BT6r2+1Wcvl583ZVkuSZ3or7Y1O2w5AvWtlvvxwjGhmz5DdPJS9xqRdDlgTJ/38ehWnEi0tFA==}
+  /vue-component-type-helpers@2.0.7:
+    resolution: {integrity: sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==}
     dev: true
 
   /vue-docgen-api@4.75.1(vue@3.4.19):
@@ -13404,9 +13404,10 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /yaml@2.3.4:
-    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+  /yaml@2.4.1:
+    resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
+    hasBin: true
     dev: false
 
   /yargs-parser@18.1.3:


### PR DESCRIPTION
## Description
Fixes [WARP-515](https://nmp-jira.atlassian.net/browse/WARP-515)

Changes based on the [Figma component library](https://www.figma.com/file/oHBCzDdJxHQ6fmFLYWUltf/Warp---Components-2.0?type=design&node-id=954-37013&mode=design&t=NPcTtpnw8dXLMG36-0):
- label color doesn't change when input is invalid
- label optional should have subtle text color (the other changes to label optional should be handled in a separate task)
- hint/error text color should be negative when input is invalid
<img width="241" alt="Screenshot of checkbox group component with label in dark grey and help text in red" src="https://github.com/warp-ds/vue/assets/41303231/fbacd68b-380b-4b9b-a133-c1ac15724b5a"><img width="236" alt="Screenshot of Radio group component with label in dark grey and help text in red" src="https://github.com/warp-ds/vue/assets/41303231/f6f2c696-92a6-4168-82d5-729f5d18f30a">

<img width="480" alt="Screenshot of Select component with label in dark grey and help text in red" src="https://github.com/warp-ds/vue/assets/41303231/252e5bc7-fac4-491a-985b-e0c241c16589">
<img width="479" alt="Screenshot of Select component with optional label in subtle grey" src="https://github.com/warp-ds/vue/assets/41303231/afd707bd-9d13-481a-a05c-dcafe9e51ba7">

