### PR TITLE
feat: add more functionality to attention component

### DIFF
--- a/components/attention/w-attention.vue
+++ b/components/attention/w-attention.vue
@@ -74,6 +74,7 @@ const attentionState = computed(() => ({
     return model.value
   },
   isCallout: props.callout,
+  isTooltip: props.tooltip,
   get actualDirection() {
     return actualDirection.value
   },

--- a/components/attention/w-attention.vue
+++ b/components/attention/w-attention.vue
@@ -45,6 +45,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  crossAxis: {
+    type: Boolean,
+    default: false
+  },
   fallbackPlacements: {
     type: Array,
     validator(values) {
@@ -89,6 +93,7 @@ const attentionState = computed(() => ({
   distance: props.distance,
   skidding: props.skidding,
   flip: props.flip,
+  crossAxis: props.crossAxis,
   fallbackPlacements: props.fallbackPlacements,
   waitForDOM: nextTick
 }));

--- a/components/attention/w-attention.vue
+++ b/components/attention/w-attention.vue
@@ -218,7 +218,7 @@ onUnmounted(async () => {
 </script>
 
 <template>
-  <div :class="attentionClasses" ref="attentionEl" v-show="model">
+  <div :class="attentionClasses" ref="attentionEl" v-show="model" v-if="props.callout || (props.targetEl !== undefined && !props.callout)">
     <div
       :role="props.role === '' ? undefined : props.tooltip ? 'tooltip' : 'img'"
       :aria-label="

--- a/dev/pages/Attention.vue
+++ b/dev/pages/Attention.vue
@@ -201,6 +201,7 @@ const dismissibleHighlightShowing = ref(false)
             highlight
             placement='left'
             flip
+            cross-axis
             :fallback-placements="['right', 'bottom', 'top']"
             :target-el="highlightTarget ? highlightTarget.$el : null"
             v-model="highlightShowing"

--- a/dev/pages/Attention.vue
+++ b/dev/pages/Attention.vue
@@ -155,6 +155,7 @@ const dismissibleHighlightShowing = ref(false)
             popover
             placement="bottom"
             can-close
+            flip
             @dismiss="dismissiblePopoverShowing = false"
             :target-el="dismissiblePopoverTarget ? dismissiblePopoverTarget.$el : null"
             v-model="dismissiblePopoverShowing"

--- a/dev/pages/Attention.vue
+++ b/dev/pages/Attention.vue
@@ -54,7 +54,7 @@ const dismissibleHighlightShowing = ref(false)
           </w-box>
           <w-attention
             tooltip
-            placement="bottom"
+            placement="top"
             :target-el="tooltipTarget ? tooltipTarget.$el : null"
             v-model="tooltipShowing"
             @focus="tooltipShowing = true"
@@ -134,8 +134,7 @@ const dismissibleHighlightShowing = ref(false)
           </w-button>
           <w-attention
             popover
-            placement="bottom"
-            flip
+            placement="right"
             :target-el="popoverTarget ? popoverTarget.$el : null"
             v-model="popoverShowing"
           >

--- a/test/wAttention.test.js
+++ b/test/wAttention.test.js
@@ -24,7 +24,7 @@ describe('attention', () => {
   test('highlight', () => {
     const defaultSlot = '<h5>Hello Warp</h5>';
     const wrapper = mount(wAttention, {
-      props: { highlight: true, modelValue: true, targetEl:'<w-button ref="highlightTarget" @click="highlightShowing = !highlightShowing">Click me</w-button>' },
+      props: { highlight: true, modelValue: true, targetEl: document.createElement('div') },
       slots: { default: defaultSlot },
     });
     assert.include(wrapper.text(), 'Hello Warp');

--- a/test/wAttention.test.js
+++ b/test/wAttention.test.js
@@ -24,7 +24,7 @@ describe('attention', () => {
   test('highlight', () => {
     const defaultSlot = '<h5>Hello Warp</h5>';
     const wrapper = mount(wAttention, {
-      props: { highlight: true, modelValue: true },
+      props: { highlight: true, modelValue: true, targetEl:'<w-button ref="highlightTarget" @click="highlightShowing = !highlightShowing">Click me</w-button>' },
       slots: { default: defaultSlot },
     });
     assert.include(wrapper.text(), 'Hello Warp');


### PR DESCRIPTION
**Note:**  Wait with merging until there is a new version of @warp-ds/core, once this [PR](https://github.com/warp-ds/core/pull/16) is merged

**Part of fixes for Jira-tickets:** [WARP-432](https://nmp-jira.atlassian.net/browse/WARP-432), [WARP-341](https://nmp-jira.atlassian.net/browse/WARP-341) & [WARP-373](https://nmp-jira.atlassian.net/browse/WARP-373)

- Add `cross-axis` prop
- Only render attention component when `targetEl` is undefined or when it is a `callout`

**To test:**
- Link with @warp-ds/core (branch: fix/remove-auto-placement)