### PR TITLE
fix: revert renaming key for w-toggle to fix radio-button

### DIFF
--- a/components/forms/w-toggle.vue
+++ b/components/forms/w-toggle.vue
@@ -48,7 +48,7 @@ const hasLabelAndValue = (e) => 'value' in e && 'label' in e;
 <template>
   <w-field v-slot="{ triggerValidation }" as="fieldset" v-bind="{ ...$attrs, ...$props }" :role="role">
     <div :class="wrapperClasses">
-      <div v-for="(toggle, i) in toggles" :key="`toggle-${i}`" :class="groupClasses">
+      <div v-for="(toggle, i) in toggles" :key="id + i + type" :class="groupClasses">
         <w-toggle-item
           v-model="model"
           :indeterminate="indeterminate"


### PR DESCRIPTION
The previous [commit](https://github.com/warp-ds/vue/commit/347ab790963154017d2b508453b56b8c4c53e088) in next introduced a bug to the radioButton, making it not apply the style for when selected.

- Revert renaming w-toggle's key