### PR TITLE
fix: clean up step and steps classes

### DIFF
--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -54,45 +54,43 @@ const getAriaLabel = (props) => {
 const stepClasses = computed(() => [
   ccStep.step,
   {
-    [ccStep.stepVertical]: vertical.value,
-    [ccStep.stepVerticalLeft]: vertical.value && left.value,
-    [ccStep.stepVerticalRight]: vertical.value && !left.value,
-    [ccStep.stepHorizontal]: !vertical.value,
+    [ccStep.vertical]: vertical.value,
+    [ccStep.alignLeft]: vertical.value && left.value,
+    [ccStep.alignRight]: vertical.value && !left.value,
+    [ccStep.horizontal]: !vertical.value,
   },
 ]);
 
 const horizontalClasses = computed(() => [
   ccStep.stepLine,
-  ccStep.stepLineHorizontalLeft,
+  ccStep.lineHorizontalAlignLeft,
   {
-    [ccStep.stepLineHorizontal]: !vertical.value,
-    [ccStep.stepLineIncomplete]: !props.active && !props.complete,
-    [ccStep.stepLineComplete]: props.active || props.complete,
+    [ccStep.lineHorizontal]: !vertical.value,
+    [ccStep.lineIncomplete]: !props.active && !props.complete,
+    [ccStep.lineComplete]: props.active || props.complete,
   },
 ]);
 
 const stepDotClasses = computed(() => [
   ccStep.stepDot,
   {
-    [ccStep.stepDotVertical]: vertical.value,
-    [ccStep.stepDotVerticalLeft]: vertical.value && left.value,
-    [ccStep.stepDotVerticalRight]: vertical.value && !left.value,
-    [ccStep.stepDotHorizontal]: !vertical.value,
-    [ccStep.stepDotIncomplete]: !(props.active || props.complete),
-    [ccStep.stepDotActive]: props.active || props.complete,
+    [ccStep.dotAlignRight]: vertical.value && !left.value,
+    [ccStep.dotHorizontal]: !vertical.value,
+    [ccStep.dotIncomplete]: !(props.active || props.complete),
+    [ccStep.dotActive]: props.active || props.complete,
   },
 ]);
 
 const stepLineClasses = computed(() => [
   ccStep.stepLine,
-  ccStep.stepLineHorizontalRight,
+  ccStep.lineHorizontalAlignRight,
   {
-    [ccStep.stepLineVertical]: vertical.value,
-    [ccStep.stepLineVerticalLeft]: vertical.value && left.value,
-    [ccStep.stepLineVerticalRight]: vertical.value && !left.value,
-    [ccStep.stepLineHorizontal]: !vertical.value,
-    [ccStep.stepLineIncomplete]: !props.complete,
-    [ccStep.stepLineComplete]: props.complete,
+    [ccStep.lineVertical]: vertical.value,
+    [ccStep.lineAlignLeft]: vertical.value && left.value,
+    [ccStep.lineAlignRight]: vertical.value && !left.value,
+    [ccStep.lineHorizontal]: !vertical.value,
+    [ccStep.lineIncomplete]: !props.complete,
+    [ccStep.lineComplete]: props.complete,
   },
 ]);
 
@@ -113,7 +111,7 @@ export default { name: 'wStep' };
   <li :class="stepClasses">
     <div v-if="!vertical" :class="horizontalClasses" />
     <div role="img" :aria-label="getAriaLabel(props)" :aria-current="active ? 'step' : undefined" :class="stepDotClasses">
-      <icon-check-16 v-if="complete" />
+      <IconCheck16 v-if="complete" />
     </div>
     <div :class="stepLineClasses" />
     <div :class="contentClasses">

--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -111,7 +111,7 @@ export default { name: 'wStep' };
   <li :class="stepClasses">
     <div v-if="!vertical" :class="horizontalClasses" />
     <div role="img" :aria-label="getAriaLabel(props)" :aria-current="active ? 'step' : undefined" :class="stepDotClasses">
-      <IconCheck16 v-if="complete" />
+      <icon-check-16 v-if="complete" />
     </div>
     <div :class="stepLineClasses" />
     <div :class="contentClasses">

--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -52,53 +52,35 @@ const getAriaLabel = (props) => {
 };
 
 const stepClasses = computed(() => [
-  ccStep.step,
-  {
-    [ccStep.vertical]: vertical.value,
-    [ccStep.alignLeft]: vertical.value && left.value,
-    [ccStep.alignRight]: vertical.value && !left.value,
-    [ccStep.horizontal]: !vertical.value,
-  },
+  ccStep.container,
+  vertical.value ? ccStep.vertical : ccStep.horizontal,
+  vertical.value ? left.value ? ccStep.alignLeft : ccStep.alignRight : ''
 ]);
 
 const lineHorizontalClasses = computed(() => [
-  ccStep.stepLine,
+  ccStep.line,
   ccStep.lineHorizontalAlignLeft,
-  {
-    [ccStep.lineHorizontal]: !vertical.value,
-    [ccStep.lineIncomplete]: !props.active && !props.complete,
-    [ccStep.lineComplete]: props.active || props.complete,
-  },
+  ccStep.lineHorizontal,
+  props.active || props.complete ? ccStep.lineComplete : ccStep.lineIncomplete
 ]);
 
 const dotClasses = computed(() => [
   ccStep.dot,
-  {
-    [ccStep.dotAlignRight]: vertical.value && !left.value,
-    [ccStep.dotHorizontal]: !vertical.value,
-    [ccStep.dotIncomplete]: !(props.active || props.complete),
-    [ccStep.dotActive]: props.active || props.complete,
-  },
+  props.active || props.complete ? ccStep.dotActive : ccStep.dotIncomplete,
+  vertical.value ? !left.value ? ccStep.dotAlignRight : '' : ccStep.dotHorizontal
 ]);
 
 const lineClasses = computed(() => [
   ccStep.line,
   ccStep.lineHorizontalAlignRight,
-  {
-    [ccStep.lineVertical]: vertical.value,
-    [ccStep.lineAlignRight]: vertical.value && !left.value,
-    [ccStep.lineHorizontal]: !vertical.value,
-    [ccStep.lineIncomplete]: !props.complete,
-    [ccStep.lineComplete]: props.complete,
-  },
+  vertical.value ? ccStep.lineVertical : ccStep.lineHorizontal,
+  vertical.value && !left.value ? ccStep.lineAlignRight : '',
+  props.complete ? ccStep.lineComplete : ccStep.lineIncomplete,
 ]);
 
 const contentClasses = computed(() => [
   ccStep.content,
-  {
-    [ccStep.contentVertical]: vertical.value,
-    [ccStep.contentHorizontal]: !vertical.value,
-  },
+  vertical.value ? ccStep.contentVertical : ccStep.contentHorizontal
 ]);
 </script>
 

--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -61,7 +61,7 @@ const stepClasses = computed(() => [
   },
 ]);
 
-const horizontalClasses = computed(() => [
+const lineHorizontalClasses = computed(() => [
   ccStep.stepLine,
   ccStep.lineHorizontalAlignLeft,
   {
@@ -71,8 +71,8 @@ const horizontalClasses = computed(() => [
   },
 ]);
 
-const stepDotClasses = computed(() => [
-  ccStep.stepDot,
+const dotClasses = computed(() => [
+  ccStep.dot,
   {
     [ccStep.dotAlignRight]: vertical.value && !left.value,
     [ccStep.dotHorizontal]: !vertical.value,
@@ -81,12 +81,11 @@ const stepDotClasses = computed(() => [
   },
 ]);
 
-const stepLineClasses = computed(() => [
-  ccStep.stepLine,
+const lineClasses = computed(() => [
+  ccStep.line,
   ccStep.lineHorizontalAlignRight,
   {
     [ccStep.lineVertical]: vertical.value,
-    [ccStep.lineAlignLeft]: vertical.value && left.value,
     [ccStep.lineAlignRight]: vertical.value && !left.value,
     [ccStep.lineHorizontal]: !vertical.value,
     [ccStep.lineIncomplete]: !props.complete,
@@ -109,11 +108,11 @@ export default { name: 'wStep' };
 
 <template>
   <li :class="stepClasses">
-    <div v-if="!vertical" :class="horizontalClasses" />
-    <div role="img" :aria-label="getAriaLabel(props)" :aria-current="active ? 'step' : undefined" :class="stepDotClasses">
+    <div v-if="!vertical" :class="lineHorizontalClasses" />
+    <div role="img" :aria-label="getAriaLabel(props)" :aria-current="active ? 'step' : undefined" :class="dotClasses">
       <icon-check-16 v-if="complete" />
     </div>
-    <div :class="stepLineClasses" />
+    <div :class="lineClasses" />
     <div :class="contentClasses">
       <slot />
     </div>

--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -54,20 +54,20 @@ const getAriaLabel = (props) => {
 const stepClasses = computed(() => [
   ccStep.container,
   vertical.value ? ccStep.vertical : ccStep.horizontal,
-  vertical.value ? left.value ? ccStep.alignLeft : ccStep.alignRight : ''
+  vertical.value ? (left.value ? ccStep.alignLeft : ccStep.alignRight) : '',
 ]);
 
 const lineHorizontalClasses = computed(() => [
   ccStep.line,
   ccStep.lineHorizontalAlignLeft,
   ccStep.lineHorizontal,
-  props.active || props.complete ? ccStep.lineComplete : ccStep.lineIncomplete
+  props.active || props.complete ? ccStep.lineComplete : ccStep.lineIncomplete,
 ]);
 
 const dotClasses = computed(() => [
   ccStep.dot,
   props.active || props.complete ? ccStep.dotActive : ccStep.dotIncomplete,
-  vertical.value ? !left.value ? ccStep.dotAlignRight : '' : ccStep.dotHorizontal
+  vertical.value ? (!left.value ? ccStep.dotAlignRight : '') : ccStep.dotHorizontal,
 ]);
 
 const lineClasses = computed(() => [
@@ -78,10 +78,7 @@ const lineClasses = computed(() => [
   props.complete ? ccStep.lineComplete : ccStep.lineIncomplete,
 ]);
 
-const contentClasses = computed(() => [
-  ccStep.content,
-  vertical.value ? ccStep.contentVertical : ccStep.contentHorizontal
-]);
+const contentClasses = computed(() => [ccStep.content, vertical.value ? ccStep.contentVertical : ccStep.contentHorizontal]);
 </script>
 
 <script>

--- a/components/steps/w-step.vue
+++ b/components/steps/w-step.vue
@@ -59,15 +59,15 @@ const stepClasses = computed(() => [
 
 const lineHorizontalClasses = computed(() => [
   ccStep.line,
-  ccStep.lineHorizontalAlignLeft,
   ccStep.lineHorizontal,
+  ccStep.lineHorizontalAlignLeft,
   props.active || props.complete ? ccStep.lineComplete : ccStep.lineIncomplete,
 ]);
 
 const dotClasses = computed(() => [
   ccStep.dot,
-  props.active || props.complete ? ccStep.dotActive : ccStep.dotIncomplete,
   vertical.value ? (!left.value ? ccStep.dotAlignRight : '') : ccStep.dotHorizontal,
+  props.active || props.complete ? ccStep.dotActive : ccStep.dotIncomplete,
 ]);
 
 const lineClasses = computed(() => [

--- a/components/steps/w-steps.vue
+++ b/components/steps/w-steps.vue
@@ -22,6 +22,10 @@ watchEffect(() => {
 });
 </script>
 
+<script>
+export default { name: 'wSteps' };
+</script>
+
 <template>
   <ul :class="stepsClasses">
     <slot />

--- a/components/steps/w-steps.vue
+++ b/components/steps/w-steps.vue
@@ -14,19 +14,12 @@ const left = ref(!props.right);
 provide('steps-vertical', vertical);
 provide('steps-left', left);
 
-const stepsClasses = computed(() => ({
-  [ccSteps.steps]: true,
-  [ccSteps.stepsHorizontal]: props.horizontal,
-}));
+const stepsClasses = computed(() => [ccSteps.container, { [ccSteps.horizontal]: props.horizontal }]);
 
 watchEffect(() => {
   vertical.value = !props.horizontal;
   left.value = !props.right;
 });
-</script>
-
-<script>
-export default { name: 'wSteps' };
 </script>
 
 <template>


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `w-step` and `w-steps` components.

**Changes:**
- Renamed class names in `w-step` and `w-steps` components.

## How to test
Either link this branch with @warp-ds/css (`fix/cleanup-steps-classes` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/cleanup-steps-classes`