### PR TITLE
fix(buttongroupitem): clean up classes

### DIFF
--- a/components/button-group/w-button-group-item.vue
+++ b/components/button-group/w-button-group-item.vue
@@ -10,7 +10,7 @@ const vertical = inject('vertical', false);
 const outlinedClass = computed(() => [
   ccButtonGroupItem.outlined,
   vertical.value ? ccButtonGroupItem.outlinedVertical : ccButtonGroupItem.outlinedHorizontal,
-  props.selected ? ccButtonGroupItem.outlinedSelected : '',
+  props.selected ? ccButtonGroupItem.outlinedSelected : ccButtonGroupItem.outlinedUnselected,
 ]);
 
 const outlineResetClass = computed(() => [
@@ -20,7 +20,7 @@ const outlineResetClass = computed(() => [
 const wrapperClass = computed(() => [
   ccButtonGroupItem.wrapper,
   outlined.value ? outlinedClass.value : outlineResetClass.value,
-  props.selected ? ccButtonGroupItem.selected : '',
+  props.selected ? ccButtonGroupItem.selected : ccButtonGroupItem.unSelected,
 ]);
 </script>
 


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `w-button-group` and `w-button-group-item` components.

**Changes:**
- Renamed class names in `w-button-group-item` component.

## How to test
Either link this branch with @warp-ds/css (`fix/cleanup-button-group-classes` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/cleanup-button-group-classes`