### PR TITLE
fix(expandable): clean up classes

### DIFF
--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -67,7 +67,7 @@ export default { name: 'wExpandable' };
 <template>
   <component :is="as" :class="wrapperClasses">
     <button v-if="hasTitle" type="button" :aria-expanded="expanded" :class="buttonClasses" @click="expanded = !expanded">
-      <div :class=ccExpandable.title>
+      <div :class="ccExpandable.title">
         <slot name="title" :expanded="expanded" />
         <span v-if="title" :class="ccExpandable.titleType">{{ title }}</span>
         <div v-if="chevron" :class="chevronClasses">

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -67,11 +67,13 @@ export default { name: 'wExpandable' };
 <template>
   <component :is="as" :class="wrapperClasses">
     <button v-if="hasTitle" type="button" :aria-expanded="expanded" :class="buttonClasses" @click="expanded = !expanded">
-      <slot name="title" :expanded="expanded" />
-      <span v-if="title" :class="ccExpandable.expandableTitle">{{ title }}</span>
-      <div v-if="chevron" :class="chevronClasses">
-        <icon-chevron-up-16 v-if="expanded" :class="chevronUpClasses" />
-        <icon-chevron-down-16 v-else :class="chevronDownClasses" />
+      <div :class=ccExpandable.title>
+        <slot name="title" :expanded="expanded" />
+        <span v-if="title" :class="ccExpandable.titleType">{{ title }}</span>
+        <div v-if="chevron" :class="chevronClasses">
+          <icon-chevron-up-16 v-if="expanded" :class="chevronUpClasses" />
+          <icon-chevron-down-16 v-else :class="chevronDownClasses" />
+        </div>
       </div>
     </button>
     <component :is="contentComponent" @expand="emit('expand')" @collapse="emit('collapse')">

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -36,10 +36,6 @@ if (!props.animated) {
   });
 }
 
-const toggleExpandable = () => {
-  expanded.value = !expanded.value;
-};
-
 const hasTitle = computed(() => props.title || !!slots.title);
 
 const wrapperClasses = computed(() => [
@@ -66,7 +62,7 @@ export default { name: 'wExpandable' };
 
 <template>
   <component :is="as" :class="wrapperClasses">
-    <button v-if="hasTitle" type="button" :aria-expanded="expanded" :class="buttonClasses" @click="toggleExpandable">
+    <button v-if="hasTitle" type="button" :aria-expanded="expanded" :class="buttonClasses" @click="expanded = !expanded">
       <slot name="title" :expanded="expanded" />
       <span v-if="title" :class="ccExpandable.expandableTitle">{{ title }}</span>
       <div v-if="chevron" :class="chevronClasses">

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -51,7 +51,11 @@ const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, !expande
 
 const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, expanded.value && ccExpandable.chevronExpand]);
 
-const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, props.box && hasTitle.value && ccExpandable.contentWithTitle]);
+const contentClasses = computed(() => [
+  props.contentClass,
+  props.box && ccBox.box,
+  props.box && hasTitle.value && ccExpandable.contentWithTitle,
+]);
 </script>
 
 <script>

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -53,7 +53,11 @@ const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, !expande
 
 const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, expanded.value && ccExpandable.chevronExpand]);
 
-const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, props.box && hasTitle.value && ccExpandable.paddingTop]);
+const contentClasses = computed(() => [
+  props.contentClass,
+  props.box && ccBox.box,
+  (props.box || props.info) && hasTitle.value && ccExpandable.paddingTop,
+]);
 </script>
 
 <script>

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -26,14 +26,21 @@ const slots = useSlots();
 
 const expanded = props.modelValue === absentProp ? ref(false) : createModel({ props, emit });
 const contentComponent = computed(() => (props.animated ? expandTransition : 'div'));
+const showChevronUp = ref(expanded.value)
 
 if (!props.animated) {
   watch(expanded, async (isExpanded) => {
     await nextTick();
     emit(isExpanded ? 'expand' : 'collapse');
-    expanded.value = isExpanded;
   });
 }
+
+// We need a slight delay for the animation since it has a transition-duration of 150ms:
+watch(expanded, (state) => {
+  setTimeout(() => {
+    showChevronUp.value = state;
+  }, 200);
+});
 
 const hasTitle = computed(() => props.title || !!slots.title);
 
@@ -47,9 +54,9 @@ const buttonClasses = computed(() => [props.buttonClass, ccExpandable.button, pr
 
 const chevronClasses = computed(() => [ccExpandable.chevron, !props.box && ccExpandable.chevronNonBox]);
 
-const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, !expanded.value && ccExpandable.chevronCollapse]);
+const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, (!expanded.value && showChevronUp.value) && ccExpandable.chevronCollapse]);
 
-const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, expanded.value && ccExpandable.chevronExpand]);
+const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, (expanded.value && !showChevronUp.value) && ccExpandable.chevronExpand]);
 
 const contentClasses = computed(() => [
   props.contentClass,
@@ -69,7 +76,7 @@ export default { name: 'wExpandable' };
         <slot name="title" :expanded="expanded" />
         <span v-if="title" :class="ccExpandable.titleType">{{ title }}</span>
         <div v-if="chevron" :class="chevronClasses">
-          <icon-chevron-up-16 v-if="expanded" :class="chevronUpClasses" />
+          <icon-chevron-up-16 v-if="showChevronUp" :class="chevronUpClasses" />
           <icon-chevron-down-16 v-else :class="chevronDownClasses" />
         </div>
       </div>

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -51,7 +51,7 @@ const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, !expande
 
 const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, expanded.value && ccExpandable.chevronExpand]);
 
-const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, props.box && hasTitle.value && ccExpandable.paddingTop]);
+const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, props.box && hasTitle.value && ccExpandable.contentWithTitle]);
 </script>
 
 <script>

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -47,13 +47,13 @@ const wrapperClasses = computed(() => [
 
 const buttonClasses = computed(() => [props.buttonClass, ccExpandable.button, props.box && ccExpandable.buttonBox]);
 
-const chevronClasses = computed(() => [ccExpandable.chevron, props.box ? ccExpandable.chevronBox : ccExpandable.chevronNonBox]);
+const chevronClasses = computed(() => [ccExpandable.chevron, !props.box && ccExpandable.chevronNonBox]);
 
 const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, !expanded.value && ccExpandable.chevronCollapse]);
 
 const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, expanded.value && ccExpandable.chevronExpand]);
 
-const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, hasTitle.value && props.box && ccExpandable.paddingTop]);
+const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, props.box && hasTitle.value && ccExpandable.paddingTop]);
 </script>
 
 <script>

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -26,8 +26,8 @@ const slots = useSlots();
 
 const expanded = props.modelValue === absentProp ? ref(false) : createModel({ props, emit });
 const contentComponent = computed(() => (props.animated ? expandTransition : 'div'));
-const showChevronUp = ref(expanded.value)
-
+const showChevronUp = ref(expanded.value);
+// wExpandTransition emits its own events and we just bubble them, but for a normal DOM element we need to create them
 if (!props.animated) {
   watch(expanded, async (isExpanded) => {
     await nextTick();
@@ -54,9 +54,15 @@ const buttonClasses = computed(() => [props.buttonClass, ccExpandable.button, pr
 
 const chevronClasses = computed(() => [ccExpandable.chevron, !props.box && ccExpandable.chevronNonBox]);
 
-const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, (!expanded.value && showChevronUp.value) && ccExpandable.chevronCollapse]);
+const chevronUpClasses = computed(() => [
+  ccExpandable.chevronTransform,
+  !expanded.value && showChevronUp.value && ccExpandable.chevronCollapse,
+]);
 
-const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, (expanded.value && !showChevronUp.value) && ccExpandable.chevronExpand]);
+const chevronDownClasses = computed(() => [
+  ccExpandable.chevronTransform,
+  expanded.value && !showChevronUp.value && ccExpandable.chevronExpand,
+]);
 
 const contentClasses = computed(() => [
   props.contentClass,

--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -13,7 +13,6 @@ const props = defineProps({
   title: String,
   box: Boolean,
   bleed: Boolean,
-  info: Boolean,
   buttonClass: String,
   contentClass: String,
   chevron: { type: Boolean, default: true },
@@ -41,7 +40,6 @@ const hasTitle = computed(() => props.title || !!slots.title);
 const wrapperClasses = computed(() => [
   ccExpandable.expandable,
   props.box && ccExpandable.expandableBox,
-  props.info && props.box && ccExpandable.expandableInfo,
   props.bleed && ccExpandable.expandableBleed,
 ]);
 
@@ -53,11 +51,7 @@ const chevronUpClasses = computed(() => [ccExpandable.chevronTransform, !expande
 
 const chevronDownClasses = computed(() => [ccExpandable.chevronTransform, expanded.value && ccExpandable.chevronExpand]);
 
-const contentClasses = computed(() => [
-  props.contentClass,
-  props.box && ccBox.box,
-  (props.box || props.info) && hasTitle.value && ccExpandable.paddingTop,
-]);
+const contentClasses = computed(() => [props.contentClass, props.box && ccBox.box, props.box && hasTitle.value && ccExpandable.paddingTop]);
 </script>
 
 <script>

--- a/dev/pages/ExpandableExample.vue
+++ b/dev/pages/ExpandableExample.vue
@@ -8,7 +8,6 @@ const expanded = ref(false);
 const modifierControls = [
   { name: 'Box', checkbox },
   { name: 'Bleed', checkbox },
-  { name: 'Info', checkbox },
   { name: 'Animated', checkbox },
 ];
 const modifiers = reactive(buildCheckboxState({ controls: modifierControls }));
@@ -23,7 +22,6 @@ const modifiers = reactive(buildCheckboxState({ controls: modifierControls }));
         v-model="expanded"
         :box="modifiers.Box"
         :bleed="modifiers.Bleed"
-        :info="modifiers.Info"
         :animated="modifiers.Animated"
         :title="`Click to ${expanded ? 'collapse' : 'expand'}`">
         <h2>Hello Warp!</h2>


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Expandable` component.

**Changes:**
- Renamed classNames in `w-expandable` component.
- Refactored `w-expandable` component
- Remove use of `expandableTitle` and use instead `ccExpandable.title` and `ccExpandable.titleType` in order to look and behave the same as in react and elements.
- Remove deprecated `info` prop
-  Replace `paddingTop` with `contentWithTitle`
 
## How to test
Either link this branch with @warp-ds/css (`fix/cleanup-expandable-component` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/cleanup-expandable-component`