### PR TITLE
fix(expandable): add missing expansion classes

### DIFF
--- a/components/expandable/w-expandable.vue
+++ b/components/expandable/w-expandable.vue
@@ -64,6 +64,8 @@ const chevronDownClasses = computed(() => [
   expanded.value && !showChevronUp.value && ccExpandable.chevronExpand,
 ]);
 
+const expansionClasses = computed(() => [ccExpandable.expansion, !expanded && ccExpandable.expansionNotExpanded]);
+
 const contentClasses = computed(() => [
   props.contentClass,
   props.box && ccBox.box,
@@ -87,7 +89,7 @@ export default { name: 'wExpandable' };
         </div>
       </div>
     </button>
-    <component :is="contentComponent" @expand="emit('expand')" @collapse="emit('collapse')">
+    <component :is="contentComponent" @expand="emit('expand')" @collapse="emit('collapse')" :class="!props.animated && expansionClasses">
       <div v-if="expanded">
         <div :class="contentClasses">
           <slot />


### PR DESCRIPTION
## Description
This PR ensures that `w-expandable` behaves the same way as the `Expandable` component does in react and elements.

**Changes:**
- Add missing expansion classes to contentComponent when `props.animated` is `false` (the expansion classes are present in the `Expandable` component in react and elements for when `props.animated` is `false`)
 