### PR TITLE
fix(attention): bump to latest version of @warp-ds/core dependency

### DIFF
--- a/dev/pages/AttentionExample.vue
+++ b/dev/pages/AttentionExample.vue
@@ -85,7 +85,7 @@ const dismissibleHighlightShowing = ref(false);
           <h2>Callout</h2>
           <div class="flex items-center">
             <w-box neutral as="h4" aria-details="callout-bubbletext" tabindex="0"> I am a box full of info </w-box>
-            <w-attention v-model="calloutShowing" callout placement="right" class="ml-8">
+            <w-attention v-model="calloutShowing" callout placement="right">
               <p id="callout-bubbletext">Hello Warp! This thing is new!</p>
             </w-attention>
           </div>
@@ -142,7 +142,7 @@ const dismissibleHighlightShowing = ref(false);
             v-model="popoverIconTargetShowing"
             popover
             placement="right-end"
-            :distance="-6"
+            :distance="-12"
             :skidding="7"
             :target-el="popoverIconTarget ? popoverIconTarget.$el : null">
             <p>Hello Warp!</p>

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@lingui/core": "4.11.2",
-    "@warp-ds/core": "1.1.6",
+    "@warp-ds/core": "1.1.7",
     "@warp-ds/css": "2.0.0",
     "@warp-ds/icons": "2.1.0",
     "@warp-ds/uno": "2.x",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 4.11.2
         version: 4.11.2
       '@warp-ds/core':
-        specifier: 1.1.6
-        version: 1.1.6(@floating-ui/dom@1.6.10)
+        specifier: 1.1.7
+        version: 1.1.7(@floating-ui/dom@1.6.10)
       '@warp-ds/css':
         specifier: 2.0.0
         version: 2.0.0(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0))))
@@ -2360,8 +2360,8 @@ packages:
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
 
-  '@warp-ds/core@1.1.6':
-    resolution: {integrity: sha512-Gp1QT2mQivAFIL5tdV4TaBrkJp1nzErjzN8rYeGKJw6FrlnzUk2pjsJYWGTkBqc9DvAzQMh1RgozRp6ylMtJWA==}
+  '@warp-ds/core@1.1.7':
+    resolution: {integrity: sha512-yLHLDBVa/yXaxJq1wRkKuISA7W9aYl0h5sXvJXFxltNu0/rAZXJ2IVF757gjcwqOPTcixchvYm0AJT3qx1pSgw==}
     peerDependencies:
       '@floating-ui/dom': 1.6.x
 
@@ -9291,7 +9291,7 @@ snapshots:
       js-beautify: 1.15.1
       vue-component-type-helpers: 2.0.29
 
-  '@warp-ds/core@1.1.6(@floating-ui/dom@1.6.10)':
+  '@warp-ds/core@1.1.7(@floating-ui/dom@1.6.10)':
     dependencies:
       '@floating-ui/dom': 1.6.10
 


### PR DESCRIPTION
Part of fixing JIRA issue: [WARP-607](https://nmp-jira.atlassian.net/browse/WARP-607)

**Changes:**
- Bump to latest version of `@warp-ds/core` to get the recent changes (where padding has been added to the attention-element)
- Adjust the distance for `Popover with icon as target element` example to align better