### PR TITLE
fix(tab): set border on selected tab to fix SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@lingui/core": "4.11.2",
     "@warp-ds/core": "1.1.7",
-    "@warp-ds/css": "2.0.0",
+    "@warp-ds/css": "2.0.1",
     "@warp-ds/icons": "2.1.0",
     "@warp-ds/uno": "2.x",
     "create-v-model": "2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.1.7
         version: 1.1.7(@floating-ui/dom@1.6.10)
       '@warp-ds/css':
-        specifier: 2.0.0
-        version: 2.0.0(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0))))
+        specifier: 2.0.1
+        version: 2.0.1(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0))))
       '@warp-ds/icons':
         specifier: 2.1.0
         version: 2.1.0
@@ -2365,8 +2365,8 @@ packages:
     peerDependencies:
       '@floating-ui/dom': 1.6.x
 
-  '@warp-ds/css@2.0.0':
-    resolution: {integrity: sha512-Q+ZKhskE2eLg3EhCDDG+ox73GtZ+47SN3MDudE8muB5ESJ2Bb7ga+hD+KnvrNJxBLzqtQxGgL13XxJyEfYf1ZQ==}
+  '@warp-ds/css@2.0.1':
+    resolution: {integrity: sha512-J0NbX56nAXasW5w5hqcKN5TRZwjWpX6oPrnILzBaGNIDDwp2GaoxIcSl2hEvPOw2+EzZbOZxgT91G4krUsoeoQ==}
     peerDependencies:
       '@warp-ds/uno': 2.x
 
@@ -6363,8 +6363,8 @@ packages:
   vue-component-type-helpers@2.0.29:
     resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
 
-  vue-component-type-helpers@2.1.6:
-    resolution: {integrity: sha512-ng11B8B/ZADUMMOsRbqv0arc442q7lifSubD0v8oDXIFoMg/mXwAPUunrroIDkY+mcD0dHKccdaznSVp8EoX3w==}
+  vue-component-type-helpers@2.1.10:
+    resolution: {integrity: sha512-lfgdSLQKrUmADiSV6PbBvYgQ33KF3Ztv6gP85MfGaGaSGMTXORVaHT1EHfsqCgzRNBstPKYDmvAV9Do5CmJ07A==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -8665,7 +8665,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.31(typescript@5.5.4)
-      vue-component-type-helpers: 2.1.6
+      vue-component-type-helpers: 2.1.10
 
   '@swc/core-darwin-arm64@1.7.10':
     optional: true
@@ -9295,7 +9295,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.6.10
 
-  '@warp-ds/css@2.0.0(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0))))':
+  '@warp-ds/css@2.0.1(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0))))':
     dependencies:
       '@warp-ds/uno': 2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0)))
 
@@ -13874,7 +13874,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.29: {}
 
-  vue-component-type-helpers@2.1.6: {}
+  vue-component-type-helpers@2.1.10: {}
 
   vue-docgen-api@4.79.2(vue@3.4.31(typescript@5.5.4)):
     dependencies:


### PR DESCRIPTION
## Description
Fixes [WARP-638](https://nmp-jira.atlassian.net/browse/WARP-638)

Update `@warp-ds/css` to `2.0.1` to get an additional `s-border-selected` in the `tabs.active` component class.

## Background
Tab's selected border has so far been styled by a "selection-indicator" `span` of the Tabs component. That span's width and position is calculated based on `getBoundingClientRect()` of the child Tab, and after an animation is finished, the correct Tab gets its bottom border. That way of indicating the selected tab does not work server-side, which led us to the solution suggested in this PR. By setting the bottom border color of the selected Tab to `s-border-selected` whenever it's active, we ensure it's styled correctly regardless of whether JavaScript is enabled or not. The animation of the span will remain, as this change does not interfere with that.

### Before - SSR without hydration (JS disabled):
<img width="313" alt="Screenshot of SSR Tabs without bottom border on the selected Tab" src="https://github.com/user-attachments/assets/934d22ff-e38c-49d5-ab48-b1d9b154126a">

### After - SSR without hydration (JS disabled):
<img width="308" alt="Screenshot of SSR Tabs with bottom border on the selected Tab" src="https://github.com/user-attachments/assets/4151e185-fd60-44ef-b783-f85d64c21bfe">

## Side effect
As a consequence of the suggested change, the selected tab style doesn't wait for the span animation to finish. Previously, when quickly removing the cursor from the activated tab, you could see that the selection indicator had to finish its animation before we could see the selected tab style:
![GIF displaying how Tabs border was not set until an animation was finished](https://github.com/user-attachments/assets/81f94d99-190a-4c42-8c44-ae51bd39590d)
With the suggested change, it looks like so:
![GIF displaying fixed Tabs border](https://github.com/user-attachments/assets/dfba7868-1b5e-490a-8e90-247ac370df13)

