### PR TITLE
fix(packages): set @warp-ds/css peer-dependency to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "#util": "./components/util/index.js"
   },
   "peerDependencies": {
-    "@warp-ds/css": "2.0.0"
+    "@warp-ds/css": "2.0.1"
   },
   "scripts": {
     "build-storybook": "storybook build",


### PR DESCRIPTION
Fixes warnings when installing the latest version of @warp-ds/vue:
```bash
 WARN  Issues with peer dependencies found
.
├─┬ @warp-ds/vue 2.1.2
│ └── ✕ unmet peer @warp-ds/css@2.0.0: found 2.0.1
```