### PR TITLE
fix(attention): move role and aria-label to attention-arrow wrapper

### DIFF
--- a/components/attention/w-attention.vue
+++ b/components/attention/w-attention.vue
@@ -224,12 +224,12 @@ export default { name: 'wAttention' };
 
 <template>
   <div v-show="model" v-if="props.callout || (props.targetEl !== undefined && !props.callout)" ref="attentionEl" :class="attentionClasses">
-    <div
-      :role="props.role === '' ? undefined : props.tooltip ? 'tooltip' : 'img'"
-      :aria-label="props.ariaLabel === '' ? undefined : props.ariaLabel ?? defaultAriaLabel"
-      :class="wrapperClasses"
-      data-test="wrapper">
-      <w-attention-arrow v-if="!noArrow" v-bind="$props" ref="arrowEl" :direction="actualDirection" />
+    <div :class="wrapperClasses" data-test="wrapper">
+      <div
+        :role="props.role === '' ? undefined : props.tooltip ? 'tooltip' : 'img'"
+        :aria-label="props.ariaLabel === '' ? undefined : props.ariaLabel ?? defaultAriaLabel">
+        <w-attention-arrow v-if="!noArrow" v-bind="$props" ref="arrowEl" :direction="actualDirection" />
+      </div>
       <div :class="ccAttention.content">
         <slot />
       </div>

--- a/dev/pages/AttentionExample.vue
+++ b/dev/pages/AttentionExample.vue
@@ -34,14 +34,12 @@ const dismissibleHighlightShowing = ref(false);
           <w-box
             ref="tooltipTarget"
             neutral
-            as="h4"
-            tabindex="0"
-            @mouseenter="tooltipShowing = true"
+            as="h4">
+            <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button" @mouseenter="tooltipShowing = true"
             @mouseleave="tooltipShowing = false"
             @keydown.escape="tooltipShowing = false"
             @focus="tooltipShowing = true"
-            @blur="tooltipShowing = false">
-            <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
+            @blur="tooltipShowing = false"class="bg-transparent">Hover over me</button>
           </w-box>
           <w-attention
             v-model="tooltipShowing"
@@ -58,14 +56,12 @@ const dismissibleHighlightShowing = ref(false);
           <w-box
             ref="tooltipResetTarget"
             neutral
-            as="h4"
-            tabindex="0"
-            @mouseenter="tooltipResetShowing = true"
+            as="h4">
+            <button aria-describedby="tooltip-reset-bubbletext" aria-expanded="true" type="button" @mouseenter="tooltipResetShowing = true"
             @mouseleave="tooltipResetShowing = false"
             @keydown.escape="tooltipResetShowing = false"
             @focus="tooltipResetShowing = true"
-            @blur="tooltipResetShowing = false">
-            <button aria-describedby="tooltip-reset-bubbletext" aria-expanded="true" type="button" class="bg-transparent">
+            @blur="tooltipResetShowing = false"class="bg-transparent">
               Hover over me
             </button>
           </w-box>
@@ -84,7 +80,7 @@ const dismissibleHighlightShowing = ref(false);
         <div>
           <h2>Callout</h2>
           <div class="flex items-center">
-            <w-box neutral as="h4" aria-details="callout-bubbletext" tabindex="0"> I am a box full of info </w-box>
+            <w-box neutral as="h4" aria-details="callout-bubbletext"> I am a box full of info </w-box>
             <w-attention v-model="calloutShowing" callout placement="right">
               <p id="callout-bubbletext">Hello Warp! This thing is new!</p>
             </w-attention>

--- a/dev/pages/AttentionExample.vue
+++ b/dev/pages/AttentionExample.vue
@@ -31,15 +31,19 @@ const dismissibleHighlightShowing = ref(false);
       <div class="space-y-16">
         <div>
           <h2>Tooltip</h2>
-          <w-box
-            ref="tooltipTarget"
-            neutral
-            as="h4">
-            <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button" @mouseenter="tooltipShowing = true"
-            @mouseleave="tooltipShowing = false"
-            @keydown.escape="tooltipShowing = false"
-            @focus="tooltipShowing = true"
-            @blur="tooltipShowing = false"class="bg-transparent">Hover over me</button>
+          <w-box ref="tooltipTarget" neutral as="h4">
+            <button
+              aria-describedby="tooltip-bubbletext"
+              aria-expanded="true"
+              type="button"
+              @mouseenter="tooltipShowing = true"
+              @mouseleave="tooltipShowing = false"
+              @keydown.escape="tooltipShowing = false"
+              @focus="tooltipShowing = true"
+              @blur="tooltipShowing = false"
+              class="bg-transparent">
+              Hover over me
+            </button>
           </w-box>
           <w-attention
             v-model="tooltipShowing"
@@ -53,15 +57,17 @@ const dismissibleHighlightShowing = ref(false);
         </div>
         <div>
           <h2>Tooltip with resetted role and aria-label attributes</h2>
-          <w-box
-            ref="tooltipResetTarget"
-            neutral
-            as="h4">
-            <button aria-describedby="tooltip-reset-bubbletext" aria-expanded="true" type="button" @mouseenter="tooltipResetShowing = true"
-            @mouseleave="tooltipResetShowing = false"
-            @keydown.escape="tooltipResetShowing = false"
-            @focus="tooltipResetShowing = true"
-            @blur="tooltipResetShowing = false"class="bg-transparent">
+          <w-box ref="tooltipResetTarget" neutral as="h4">
+            <button
+              aria-describedby="tooltip-reset-bubbletext"
+              aria-expanded="true"
+              type="button"
+              @mouseenter="tooltipResetShowing = true"
+              @mouseleave="tooltipResetShowing = false"
+              @keydown.escape="tooltipResetShowing = false"
+              @focus="tooltipResetShowing = true"
+              @blur="tooltipResetShowing = false"
+              class="bg-transparent">
               Hover over me
             </button>
           </w-box>

--- a/dev/pages/AttentionExample.vue
+++ b/dev/pages/AttentionExample.vue
@@ -31,19 +31,16 @@ const dismissibleHighlightShowing = ref(false);
       <div class="space-y-16">
         <div>
           <h2>Tooltip</h2>
-          <w-box ref="tooltipTarget" neutral as="h4">
-            <button
-              aria-describedby="tooltip-bubbletext"
-              aria-expanded="true"
-              type="button"
-              @mouseenter="tooltipShowing = true"
-              @mouseleave="tooltipShowing = false"
-              @keydown.escape="tooltipShowing = false"
-              @focus="tooltipShowing = true"
-              @blur="tooltipShowing = false"
-              class="bg-transparent">
-              Hover over me
-            </button>
+          <w-box
+            ref="tooltipTarget"
+            neutral
+            as="h4"
+            @mouseenter="tooltipShowing = true"
+            @mouseleave="tooltipShowing = false"
+            @keydown.escape="tooltipShowing = false"
+            @focus="tooltipShowing = true"
+            @blur="tooltipShowing = false">
+            <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
           </w-box>
           <w-attention
             v-model="tooltipShowing"
@@ -57,17 +54,16 @@ const dismissibleHighlightShowing = ref(false);
         </div>
         <div>
           <h2>Tooltip with resetted role and aria-label attributes</h2>
-          <w-box ref="tooltipResetTarget" neutral as="h4">
-            <button
-              aria-describedby="tooltip-reset-bubbletext"
-              aria-expanded="true"
-              type="button"
-              @mouseenter="tooltipResetShowing = true"
-              @mouseleave="tooltipResetShowing = false"
-              @keydown.escape="tooltipResetShowing = false"
-              @focus="tooltipResetShowing = true"
-              @blur="tooltipResetShowing = false"
-              class="bg-transparent">
+          <w-box
+            ref="tooltipResetTarget"
+            neutral
+            as="h4"
+            @mouseenter="tooltipResetShowing = true"
+            @mouseleave="tooltipResetShowing = false"
+            @keydown.escape="tooltipResetShowing = false"
+            @focus="tooltipResetShowing = true"
+            @blur="tooltipResetShowing = false">
+            <button aria-describedby="tooltip-reset-bubbletext" aria-expanded="true" type="button" class="bg-transparent">
               Hover over me
             </button>
           </w-box>


### PR DESCRIPTION
Fixes Jira issue: [WARP-651](https://nmp-jira.atlassian.net/browse/WARP-651)

**Changes include:**
- Move `role` and `aria-label` from the `div` wrapping the speech bubble to a `div` that is wrapping the `attention-arrow` component
- Remove `tabindex="0"` from non-interactive elements in `AttentionExample.vue`.
