### PR TITLE
fix(lingui): add lingui compile to postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@lingui/core": "4.11.2",
     "@warp-ds/core": "1.1.8",
     "@warp-ds/css": "2.0.1",
-    "@warp-ds/icons": "2.3.0",
+    "@warp-ds/icons": "2.4.0",
     "@warp-ds/uno": "2.x",
     "create-v-model": "2.2.0",
     "dom-focus-lock": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,18 +36,19 @@
   },
   "scripts": {
     "build-storybook": "storybook build",
-    "build": "lingui compile && vite build --mode lib && vite build --mode eik",
+    "build": "vite build --mode lib && vite build --mode eik",
     "commit": "cz",
     "dev": "vite dev dev --config ./vite.config.js",
     "lint:check": "eslint . --ext js,vue,cjs,mjs --ignore-path .gitignore",
     "lint": "eslint . --fix --ext js,vue,cjs,mjs --ignore-path .gitignore",
     "messages:compile": "lingui compile",
     "messages:extract": "lingui extract",
+    "postinstall": "lingui compile",
     "postsite": "cd dev/dist && cp index.html 200.html && cp index.html 404.html",
     "site": "vite build dev --config ./vite.config.js",
     "storybook": "storybook dev -p 6006",
-    "test": "lingui compile && vitest run --coverage",
-    "watch": "lingui compile && vitest watch"
+    "test": "vitest run --coverage",
+    "watch": "vitest watch"
   },
   "keywords": [],
   "license": "Apache-2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0))))
       '@warp-ds/icons':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@warp-ds/uno':
         specifier: 2.x
         version: 2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0)))
@@ -2378,8 +2378,8 @@ packages:
       eslint-plugin-import: ^2.29.1
       eslint-plugin-prettier: ^5.1.3
 
-  '@warp-ds/icons@2.3.0':
-    resolution: {integrity: sha512-8IYsk0mvD0DSYm3cmOOXf/iG5vH7iN5fM1h8GPWtNcPFesRfr/OwZfeba0ESL/53MKDPO10BzwHmZ31kY/Wrow==}
+  '@warp-ds/icons@2.4.0':
+    resolution: {integrity: sha512-nXjnNjxPOxUZiFNS3gzS8C129hu6cHKNkjsflTyQKescSATo26m4byV0he0+7VVpfW8AjB0nz8nOiuLWY5D3UA==}
 
   '@warp-ds/uno@2.0.0':
     resolution: {integrity: sha512-1X67+dsZS6m1FMlMkRgEIOww0tRzTrG4wgMGJa6rAZ9Zdb+5BZAkxRqeq+3Bix7iDn3548+NEidLF3uZWNW3aA==}
@@ -9307,7 +9307,7 @@ snapshots:
       eslint-plugin-import: 2.29.1(eslint@8.57.0)
       eslint-plugin-prettier: 5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
 
-  '@warp-ds/icons@2.3.0': {}
+  '@warp-ds/icons@2.4.0': {}
 
   '@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@22.2.0)))':
     dependencies:


### PR DESCRIPTION
Fixes JIRA issue: [WARP-665](https://nmp-jira.atlassian.net/browse/WARP-665)

**Changes in package.json include:**
- Remove `lingui compile` from build, test and watch scripts
- Add `"postinstall": lingui compile`
- Bump to latest version of `@warp-ds/icons` to include Swedish translations